### PR TITLE
[fix] 한글로 된 이모지 수정

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## :어깨를_으쓱하는_남성: Description
+## :man_shrugging: Description
 
 <!-- 구현 한 기능에 대해 작성해 주세요. -->
 


### PR DESCRIPTION
:어깨를_으쓱하는_남성: -> :man_shrugging:

깃허브에서는 한글로 된 이모지를 지원하지 않습니다.  
따라서 잘못된 이모지 사용법을 수정하였습니다.