### PR TITLE
[chore] CI에서 `google-service.json`이 존재하지 않는 문제 해결

### DIFF
--- a/.github/workflows/lint_and_build.yml
+++ b/.github/workflows/lint_and_build.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Decode Google Services JSON
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo $GOOGLE_SERVICES_JSON > ./app/google-services.json
+
       - name: check ktlint
         run: ./gradlew ktlintCheck
 


### PR DESCRIPTION
<!-- ex) close #10, resolves #123 -->

## :man_shrugging: Description

- github secrets를 이용하여 google-service.json 파일 생성
