### PR TITLE
[feat] 날짜만 표시되는 달력 구현

### DIFF
--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/Label.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/Label.kt
@@ -2,4 +2,6 @@ package com.boostcamp.dreamteam.dreamdiary.core.model
 
 data class Label(
     val name: String,
-)
+) {
+    constructor() : this("")
+}

--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/Label.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/Label.kt
@@ -2,6 +2,4 @@ package com.boostcamp.dreamteam.dreamdiary.core.model
 
 data class Label(
     val name: String,
-) {
-    constructor() : this("")
-}
+)

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -89,7 +89,7 @@ private fun DiaryCalendarHeader(
                 verticalAlignment = Alignment.Bottom,
             ) {
                 Text(
-                    text = yearMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault()),
+                    text = yearMonth.month.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
                     color = MaterialTheme.colorScheme.onSurface,
                     style = MaterialTheme.typography.titleLarge,
                 )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -29,6 +29,11 @@ import java.time.YearMonth
 import java.time.format.TextStyle
 import java.util.Locale
 
+/*
+* TODO
+* https://github.com/boostcampwm-2024/and01-dreamDiary/pull/70#discussion_r1835900191
+* YearMonth를 어디에서 관리해야 할 지 고민해보기
+* */
 @Composable
 internal fun DiaryCalendar(
     modifier: Modifier = Modifier,

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -1,0 +1,93 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBackIos
+import androidx.compose.material.icons.automirrored.outlined.ArrowForwardIos
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
+
+@Composable
+internal fun DiaryCalendar(modifier: Modifier = Modifier) {
+    var selectedYearMonth by remember { mutableStateOf(YearMonth.now()) }
+
+    Column(modifier = modifier) {
+        DiaryCalendarHeader(
+            yearMonth = selectedYearMonth,
+            onPreviousMonthClick = { selectedYearMonth = selectedYearMonth.minusMonths(1) },
+            onNextMonthClick = { selectedYearMonth = selectedYearMonth.plusMonths(1) },
+            onMonthTextClick = { },
+        )
+
+        DiaryCalendarBody(yearMonth = selectedYearMonth, modifier = Modifier.fillMaxWidth())
+    }
+}
+
+@Composable
+fun DiaryCalendarHeader(
+    yearMonth: YearMonth,
+    onPreviousMonthClick: () -> Unit,
+    onNextMonthClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    onMonthTextClick: () -> Unit = { },
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = onPreviousMonthClick) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ArrowBackIos,
+                contentDescription = "이전 달로 이동",
+            )
+        }
+        Row(
+            modifier = Modifier.clickable(onClick = onMonthTextClick),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            Text(
+                text = yearMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault()),
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Text(
+                text = yearMonth.year.toString(),
+                color = MaterialTheme.colorScheme.secondary,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Light,
+            )
+        }
+        IconButton(onClick = onNextMonthClick) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ArrowForwardIos,
+                contentDescription = "다음 달로 이동",
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DiaryCalendarPreview() {
+    DreamdiaryTheme {
+        DiaryCalendar()
+    }
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -63,7 +63,7 @@ internal fun DiaryCalendar(
 }
 
 @Composable
-fun DiaryCalendarHeader(
+private fun DiaryCalendarHeader(
     yearMonth: YearMonth,
     onPreviousMonthClick: () -> Unit,
     onNextMonthClick: () -> Unit,

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -33,17 +33,18 @@ internal fun DiaryCalendar(
     modifier: Modifier = Modifier,
     yearMonth: YearMonth = YearMonth.now(),
 ) {
-    var selectedYearMonth by remember { mutableStateOf(yearMonth) }
+    var currentYearMonth by remember { mutableStateOf(yearMonth) }
+    var isYearMonthPickerOpen by remember { mutableStateOf(false) }
 
     Column(modifier = modifier) {
         DiaryCalendarHeader(
-            yearMonth = selectedYearMonth,
-            onPreviousMonthClick = { selectedYearMonth = selectedYearMonth.minusMonths(1) },
-            onNextMonthClick = { selectedYearMonth = selectedYearMonth.plusMonths(1) },
-            onMonthTextClick = { /*TODO: 년 월을 선택하는 dialog 표시*/ },
+            yearMonth = currentYearMonth,
+            onPreviousMonthClick = { currentYearMonth = currentYearMonth.minusMonths(1) },
+            onNextMonthClick = { currentYearMonth = currentYearMonth.plusMonths(1) },
+            onMonthTextClick = { isYearMonthPickerOpen = true },
         )
 
-        DiaryCalendarBody(yearMonth = selectedYearMonth, modifier = Modifier.fillMaxWidth())
+        DiaryCalendarBody(yearMonth = currentYearMonth, modifier = Modifier.fillMaxWidth())
     }
 }
 

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,6 +53,8 @@ internal fun DiaryCalendar(
             yearMonth = currentYearMonth,
             onPreviousMonthClick = { currentYearMonth = currentYearMonth.minusMonths(1) },
             onNextMonthClick = { currentYearMonth = currentYearMonth.plusMonths(1) },
+            onTodayClick = { currentYearMonth = YearMonth.now() },
+            modifier = Modifier.fillMaxWidth(),
             onMonthTextClick = { isYearMonthPickerOpen = true },
         )
 
@@ -64,37 +67,52 @@ fun DiaryCalendarHeader(
     yearMonth: YearMonth,
     onPreviousMonthClick: () -> Unit,
     onNextMonthClick: () -> Unit,
+    onTodayClick: () -> Unit,
     modifier: Modifier = Modifier,
     onMonthTextClick: () -> Unit = { },
+    today: YearMonth = YearMonth.now(),
 ) {
-    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        IconButton(onClick = onPreviousMonthClick) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.ArrowBackIos,
-                contentDescription = stringResource(R.string.calendar_previous_month),
-            )
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onPreviousMonthClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.ArrowBackIos,
+                    contentDescription = stringResource(R.string.calendar_previous_month),
+                )
+            }
+            Row(
+                modifier = Modifier.clickable(onClick = onMonthTextClick),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                Text(
+                    text = yearMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault()),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                Text(
+                    text = yearMonth.year.toString(),
+                    color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.6f),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+            IconButton(onClick = onNextMonthClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.ArrowForwardIos,
+                    contentDescription = stringResource(R.string.calendar_move_next_month),
+                )
+            }
         }
-        Row(
-            modifier = Modifier.clickable(onClick = onMonthTextClick),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.Bottom,
-        ) {
-            Text(
-                text = yearMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault()),
-                color = MaterialTheme.colorScheme.onSurface,
-                style = MaterialTheme.typography.titleLarge,
-            )
-            Text(
-                text = yearMonth.year.toString(),
-                color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.6f),
-                style = MaterialTheme.typography.titleMedium,
-            )
-        }
-        IconButton(onClick = onNextMonthClick) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.ArrowForwardIos,
-                contentDescription = stringResource(R.string.calendar_move_next_month),
-            )
+        if (yearMonth != today) {
+            TextButton(onClick = onTodayClick) {
+                Text(
+                    text = stringResource(R.string.calendar_today),
+                    color = MaterialTheme.colorScheme.secondary,
+                )
+            }
         }
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -19,24 +19,29 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import java.time.YearMonth
 import java.time.format.TextStyle
 import java.util.Locale
 
 @Composable
-internal fun DiaryCalendar(modifier: Modifier = Modifier) {
-    var selectedYearMonth by remember { mutableStateOf(YearMonth.now()) }
+internal fun DiaryCalendar(
+    modifier: Modifier = Modifier,
+    yearMonth: YearMonth = YearMonth.now(),
+) {
+    var selectedYearMonth by remember { mutableStateOf(yearMonth) }
 
     Column(modifier = modifier) {
         DiaryCalendarHeader(
             yearMonth = selectedYearMonth,
             onPreviousMonthClick = { selectedYearMonth = selectedYearMonth.minusMonths(1) },
             onNextMonthClick = { selectedYearMonth = selectedYearMonth.plusMonths(1) },
-            onMonthTextClick = { },
+            onMonthTextClick = { /*TODO: 년 월을 선택하는 dialog 표시*/ },
         )
 
         DiaryCalendarBody(yearMonth = selectedYearMonth, modifier = Modifier.fillMaxWidth())
@@ -55,7 +60,7 @@ fun DiaryCalendarHeader(
         IconButton(onClick = onPreviousMonthClick) {
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.ArrowBackIos,
-                contentDescription = "이전 달로 이동",
+                contentDescription = stringResource(R.string.calendar_previous_month),
             )
         }
         Row(
@@ -78,7 +83,7 @@ fun DiaryCalendarHeader(
         IconButton(onClick = onNextMonthClick) {
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.ArrowForwardIos,
-                contentDescription = "다음 달로 이동",
+                contentDescription = stringResource(R.string.calendar_move_next_month),
             )
         }
     }
@@ -86,8 +91,24 @@ fun DiaryCalendarHeader(
 
 @Preview(showBackground = true)
 @Composable
-private fun DiaryCalendarPreview() {
+private fun DiaryCalendarPreview1() {
     DreamdiaryTheme {
-        DiaryCalendar()
+        DiaryCalendar(yearMonth = YearMonth.of(2024, 1))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DiaryCalendarPreview2() {
+    DreamdiaryTheme {
+        DiaryCalendar(yearMonth = YearMonth.of(2024, 2))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DiaryCalendarPreview3() {
+    DreamdiaryTheme {
+        DiaryCalendar(yearMonth = YearMonth.of(2024, 3))
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
@@ -75,9 +74,8 @@ fun DiaryCalendarHeader(
             )
             Text(
                 text = yearMonth.year.toString(),
-                color = MaterialTheme.colorScheme.secondary,
+                color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.6f),
                 style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Light,
             )
         }
         IconButton(onClick = onNextMonthClick) {

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -37,6 +37,17 @@ internal fun DiaryCalendar(
     var isYearMonthPickerOpen by remember { mutableStateOf(false) }
 
     Column(modifier = modifier) {
+        if (isYearMonthPickerOpen) {
+            YearMonthPicker(
+                currentYearMonth = currentYearMonth,
+                onConfirmClick = {
+                    currentYearMonth = it
+                    isYearMonthPickerOpen = false
+                },
+                onCancelClick = { isYearMonthPickerOpen = false },
+            )
+        }
+
         DiaryCalendarHeader(
             yearMonth = currentYearMonth,
             onPreviousMonthClick = { currentYearMonth = currentYearMonth.minusMonths(1) },

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
@@ -3,6 +3,7 @@ package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -10,7 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import java.time.DayOfWeek
@@ -50,6 +53,7 @@ internal fun DiaryCalendarBody(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+        HorizontalDivider()
     }
 }
 
@@ -62,12 +66,18 @@ private fun WeekHeader(
 
     Row(modifier = modifier) {
         reorderedDays.forEach { i ->
-            DayCell(modifier = Modifier.weight(1f)) {
+            DayCell(
+                modifier = Modifier.weight(1f),
+                minHeight = 24.dp,
+            ) {
                 Text(
                     text = DayOfWeek.of(i).getDisplayName(
                         TextStyle.SHORT,
                         locale,
                     ),
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    style = MaterialTheme.typography.titleMedium,
                 )
             }
         }
@@ -82,7 +92,9 @@ private fun WeekRow(
 ) {
     Row(modifier = modifier) {
         for (i in 0 until 7) {
-            DayCell(modifier = Modifier.weight(1f)) {
+            DayCell(
+                modifier = Modifier.weight(1f),
+            ) {
                 val day = firstDateOfWeek.plusDays(i.toLong())
                 Text(
                     text = (day.dayOfMonth).toString(),
@@ -91,6 +103,7 @@ private fun WeekRow(
                     } else {
                         MaterialTheme.colorScheme.onSurface
                     },
+                    fontWeight = FontWeight.SemiBold,
                     style = MaterialTheme.typography.bodyMedium,
                 )
             }
@@ -101,10 +114,12 @@ private fun WeekRow(
 @Composable
 private fun DayCell(
     modifier: Modifier = Modifier,
+    minHeight: Dp = 48.dp,
     content: @Composable () -> Unit = {},
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier.defaultMinSize(minHeight = minHeight),
+        verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         content()

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
@@ -1,0 +1,107 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAdjusters
+import java.time.temporal.WeekFields
+import java.util.Locale
+
+@Composable
+internal fun DiaryCalendarBody(
+    yearMonth: YearMonth,
+    modifier: Modifier = Modifier,
+    locale: Locale = Locale.getDefault(),
+) {
+    val firstDayOfMonth = yearMonth.atDay(1)
+    val lastDayOfMonth = yearMonth.atEndOfMonth()
+
+    val firstDayOfWeek = WeekFields.of(locale).firstDayOfWeek
+    val firstDayOfFirstWeek = firstDayOfMonth.with(TemporalAdjusters.previousOrSame(firstDayOfWeek))
+    val weeksInMonth = ChronoUnit.WEEKS.between(firstDayOfFirstWeek, lastDayOfMonth) + 1
+
+    Column(
+        verticalArrangement = Arrangement.Top,
+        modifier = modifier,
+    ) {
+        WeekHeader(
+            modifier = Modifier.fillMaxWidth(),
+        )
+        for (i in 0 until weeksInMonth.toInt()) {
+            HorizontalDivider()
+            WeekRow(
+                firstDateOfWeek = firstDayOfFirstWeek.plusWeeks(i.toLong()),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun WeekHeader(
+    modifier: Modifier = Modifier,
+    locale: Locale = Locale.getDefault(),
+) {
+    val reorderedDays = (0 until 7).map { (it + 6) % 7 + 1 }
+
+    Row(modifier = modifier) {
+        reorderedDays.forEach { i ->
+            DayCell(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = DayOfWeek.of(i).getDisplayName(
+                        TextStyle.SHORT,
+                        locale,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WeekRow(
+    firstDateOfWeek: LocalDate,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier) {
+        for (i in 0 until 7) {
+            DayCell(modifier = Modifier.weight(1f)) {
+                Text(text = (firstDateOfWeek.plusDays(i.toLong()).dayOfMonth).toString())
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayCell(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit = {},
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        content()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CalendarBodyPreview() {
+    DreamdiaryTheme {
+        DiaryCalendarBody(yearMonth = YearMonth.now())
+    }
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -43,6 +45,7 @@ internal fun DiaryCalendarBody(
         for (i in 0 until weeksInMonth.toInt()) {
             HorizontalDivider()
             WeekRow(
+                currentYearMonth = yearMonth,
                 firstDateOfWeek = firstDayOfFirstWeek.plusWeeks(i.toLong()),
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -73,13 +76,23 @@ private fun WeekHeader(
 
 @Composable
 private fun WeekRow(
+    currentYearMonth: YearMonth,
     firstDateOfWeek: LocalDate,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier = modifier) {
         for (i in 0 until 7) {
             DayCell(modifier = Modifier.weight(1f)) {
-                Text(text = (firstDateOfWeek.plusDays(i.toLong()).dayOfMonth).toString())
+                val day = firstDateOfWeek.plusDays(i.toLong())
+                Text(
+                    text = (day.dayOfMonth).toString(),
+                    color = if (day.month != currentYearMonth.month) {
+                        MaterialTheme.colorScheme.secondary.copy(alpha = 0.4f)
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                )
             }
         }
     }
@@ -102,6 +115,6 @@ private fun DayCell(
 @Composable
 private fun CalendarBodyPreview() {
     DreamdiaryTheme {
-        DiaryCalendarBody(yearMonth = YearMonth.now())
+        DiaryCalendarBody(yearMonth = YearMonth.of(2024, 1))
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
@@ -1,6 +1,8 @@
 package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
@@ -11,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -92,13 +95,14 @@ private fun WeekRow(
 ) {
     Row(modifier = modifier) {
         for (i in 0 until 7) {
+            val date = firstDateOfWeek.plusDays(i.toLong())
             DayCell(
                 modifier = Modifier.weight(1f),
+                isToday = date == LocalDate.now(),
             ) {
-                val day = firstDateOfWeek.plusDays(i.toLong())
                 Text(
-                    text = (day.dayOfMonth).toString(),
-                    color = if (day.month != currentYearMonth.month) {
+                    text = (date.dayOfMonth).toString(),
+                    color = if (date.month != currentYearMonth.month) {
                         MaterialTheme.colorScheme.secondary.copy(alpha = 0.4f)
                     } else {
                         MaterialTheme.colorScheme.onSurface
@@ -115,13 +119,24 @@ private fun WeekRow(
 private fun DayCell(
     modifier: Modifier = Modifier,
     minHeight: Dp = 48.dp,
+    isToday: Boolean = false,
     content: @Composable () -> Unit = {},
 ) {
-    Column(
+    Box(
         modifier = modifier.defaultMinSize(minHeight = minHeight),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
+        contentAlignment = Alignment.Center,
     ) {
+        if (isToday) {
+            val circleColor = MaterialTheme.colorScheme.primary
+            Canvas(modifier = Modifier.matchParentSize()) {
+                drawCircle(
+                    color = circleColor,
+                    radius = size.minDimension / 3,
+                    style = Stroke(width = 2.dp.toPx()),
+                )
+            }
+        }
+
         content()
     }
 }
@@ -130,6 +145,6 @@ private fun DayCell(
 @Composable
 private fun CalendarBodyPreview() {
     DreamdiaryTheme {
-        DiaryCalendarBody(yearMonth = YearMonth.of(2024, 1))
+        DiaryCalendarBody(yearMonth = YearMonth.now())
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarTab.kt
@@ -2,8 +2,18 @@ package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 
 @Composable
 internal fun DiaryCalendarTab(modifier: Modifier = Modifier) {
-    // TODO: Calendar 탭 구현
+    DiaryCalendar(modifier = modifier)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DiaryCalendarTabPreview() {
+    DreamdiaryTheme {
+        DiaryCalendarTab()
+    }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarTab.kt
@@ -1,13 +1,18 @@
 package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 
 @Composable
 internal fun DiaryCalendarTab(modifier: Modifier = Modifier) {
-    DiaryCalendar(modifier = modifier)
+    Surface(modifier = modifier) {
+        DiaryCalendar(modifier = Modifier.padding(horizontal = 16.dp))
+    }
 }
 
 @Preview(showBackground = true)

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarYearMonthPicker.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarYearMonthPicker.kt
@@ -1,0 +1,190 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBackIos
+import androidx.compose.material.icons.automirrored.outlined.ArrowForwardIos
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
+import java.time.Month
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
+
+@Composable
+internal fun YearMonthPicker(
+    currentYearMonth: YearMonth,
+    onConfirmClick: (YearMonth) -> Unit,
+    onCancelClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showingYear by remember { mutableIntStateOf(currentYearMonth.year) }
+    var selectedYearMonth by remember { mutableStateOf(currentYearMonth) }
+
+    Dialog(onDismissRequest = { onConfirmClick(selectedYearMonth) }) {
+        Surface(
+            modifier = modifier,
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                YearMonthPickerHeader(
+                    year = showingYear,
+                    onBackClick = { showingYear-- },
+                    onNextClick = { showingYear++ },
+                    modifier = Modifier,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+
+                YearMonthPickerBody(
+                    showingYear = showingYear,
+                    selectedYearMonth = selectedYearMonth,
+                    modifier = Modifier,
+                    onYearMonthClick = { selectedYearMonth = it },
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+
+                YearMonthPickerActions(
+                    onConfirmClick = { onConfirmClick(selectedYearMonth) },
+                    onCancelClick = onCancelClick,
+                    modifier = Modifier.align(Alignment.End),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun YearMonthPickerActions(
+    onConfirmClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.End,
+    ) {
+        TextButton(onClick = onCancelClick) {
+            Text(text = "취소")
+        }
+        TextButton(onClick = onConfirmClick) {
+            Text(text = "확인")
+        }
+    }
+}
+
+@Composable
+private fun YearMonthPickerHeader(
+    year: Int,
+    onBackClick: () -> Unit,
+    onNextClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    currentYearMonth: YearMonth = YearMonth.now(),
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        IconButton(onClick = onBackClick) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ArrowBackIos,
+                contentDescription = stringResource(R.string.calendar_previous_month),
+            )
+        }
+        Text(
+            text = year.toString(),
+            style = MaterialTheme.typography.titleLarge,
+        )
+        IconButton(
+            onClick = onNextClick,
+            enabled = !YearMonth.of(year, Month.DECEMBER).isAfter(currentYearMonth),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ArrowForwardIos,
+                contentDescription = stringResource(R.string.calendar_move_next_month),
+            )
+        }
+    }
+}
+
+@Composable
+private fun YearMonthPickerBody(
+    showingYear: Int,
+    selectedYearMonth: YearMonth,
+    onYearMonthClick: (YearMonth) -> Unit,
+    modifier: Modifier = Modifier,
+    locale: Locale = Locale.getDefault(),
+    currentYearMonth: YearMonth = YearMonth.now(),
+) {
+    val yearMonths = Month.entries.map { YearMonth.of(showingYear, it) }
+
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        modifier = modifier,
+    ) {
+        items(yearMonths) { yearMonth ->
+            val enabled = !yearMonth.isAfter(currentYearMonth)
+
+            TextButton(
+                onClick = { onYearMonthClick(yearMonth) },
+                enabled = enabled,
+            ) {
+                Text(
+                    text = yearMonth.month.getDisplayName(TextStyle.SHORT, locale),
+                    maxLines = 1,
+                    textAlign = TextAlign.Center,
+                    color = when {
+                        yearMonth == selectedYearMonth -> MaterialTheme.colorScheme.primary
+                        !enabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                        else -> MaterialTheme.colorScheme.onSurface
+                    },
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun YearMonthPickerPreview() {
+    DreamdiaryTheme {
+        YearMonthPicker(
+            currentYearMonth = YearMonth.now(),
+            onConfirmClick = { },
+            onCancelClick = { },
+        )
+    }
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarYearMonthPicker.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarYearMonthPicker.kt
@@ -96,10 +96,10 @@ private fun YearMonthPickerActions(
         horizontalArrangement = Arrangement.End,
     ) {
         TextButton(onClick = onCancelClick) {
-            Text(text = "취소")
+            Text(text = stringResource(R.string.calendar_cancel))
         }
         TextButton(onClick = onConfirmClick) {
-            Text(text = "확인")
+            Text(text = stringResource(R.string.calendar_ok))
         }
     }
 }

--- a/feature/diary/src/main/res/values/strings.xml
+++ b/feature/diary/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
     <string name="login_google_icon">구글 아이콘</string>
     <string name="login_google_login">구글 로그인</string>
     <string name="login_now_pass">지금은 건너뛰기</string>
+    <string name="calendar_previous_month">이전 달로 이동</string>
+    <string name="calendar_move_next_month">다음 달로 이동</string>
 </resources>

--- a/feature/diary/src/main/res/values/strings.xml
+++ b/feature/diary/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
     <string name="calendar_previous_month">이전 달로 이동</string>
     <string name="calendar_move_next_month">다음 달로 이동</string>
     <string name="calendar_today">오늘</string>
+    <string name="calendar_cancel">취소</string>
+    <string name="calendar_ok">확인</string>
 </resources>

--- a/feature/diary/src/main/res/values/strings.xml
+++ b/feature/diary/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="login_now_pass">지금은 건너뛰기</string>
     <string name="calendar_previous_month">이전 달로 이동</string>
     <string name="calendar_move_next_month">다음 달로 이동</string>
+    <string name="calendar_today">오늘</string>
 </resources>


### PR DESCRIPTION
close #53
<!-- ex) close #10, resolves #123 -->

## :man_shrugging: Description

- [x] 날짜만 표시되는 달력 구현
	- 오늘 날짜를 표시
	- 오늘로 이동하는
	- 년, 월을 선택하기 위한 다이얼로그
	- 이전, 이후 월로 이동 가능한 버튼

## :camera: Screenshots

<p align="center">
  <img
    src="https://github.com/user-attachments/assets/c07984df-2b97-429c-add5-73065480beb6"
    width="30%"
  />
  <img
    src="https://github.com/user-attachments/assets/d60a9ee5-aa17-4b39-965b-75d6ee06d275"
    width="30%"
  />
  <img
    src="https://github.com/user-attachments/assets/2fb0feff-3eb0-4916-8700-39bfcb05cc03"
    width="30%"
  />
</p>

## :memo: TODO

- [ ] 특정 요일에 해당하는 다이어리가 있을 경우 표시
- [ ] 특정 요일 선택시 Bottom sheet 표시




<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
