### PR TITLE
[refactor] tab별 uistate 클래스 분리

### DIFF
--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -28,9 +28,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.DiaryCalendarTab
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.DiaryListTab
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.diariesPreview
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tabcalendar.DiaryCalendarTab
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.DiaryListTab
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.diariesPreview
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
 
 @Composable

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -39,8 +39,8 @@ fun DiaryHomeScreen(
     onFabClick: () -> Unit,
     viewModel: DiaryHomeViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.diaryHomeUIState.collectAsStateWithLifecycle()
-    val diaries = state.diaries
+    val tabListUIState by viewModel.tabListUIState.collectAsStateWithLifecycle()
+    val diaries = tabListUIState.diaries
     DiaryHomeScreenContent(
         diaries = diaries,
         onMenuClick = { /*TODO*/ },

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -29,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tabcalendar.DiaryCalendarTab
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.DiaryHomeTabListUIState
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.DiaryListTab
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.diariesPreview
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
@@ -39,10 +40,9 @@ fun DiaryHomeScreen(
     onFabClick: () -> Unit,
     viewModel: DiaryHomeViewModel = hiltViewModel(),
 ) {
-    val tabListUIState by viewModel.tabListUIState.collectAsStateWithLifecycle()
-    val diaries = tabListUIState.diaries
+    val listUIState by viewModel.tabListUIState.collectAsStateWithLifecycle()
     DiaryHomeScreenContent(
-        diaries = diaries,
+        listUIState = listUIState,
         onMenuClick = { /*TODO*/ },
         onSearchClick = { /*TODO*/ },
         onNotificationClick = { /*TODO*/ },
@@ -54,7 +54,7 @@ fun DiaryHomeScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DiaryHomeScreenContent(
-    diaries: List<DiaryUi>,
+    listUIState: DiaryHomeTabListUIState,
     modifier: Modifier = Modifier,
     onMenuClick: () -> Unit = {},
     onSearchClick: () -> Unit = {},
@@ -111,7 +111,7 @@ private fun DiaryHomeScreenContent(
 
             when (selectedTabIndex) {
                 0 -> DiaryListTab(
-                    diaries = diaries,
+                    uiState = listUIState,
                     modifier = Modifier.fillMaxSize(),
                     onDiaryClick = onDiaryClick,
                 )
@@ -169,7 +169,9 @@ private fun DiaryHomeScreenTopAppBar(
 private fun DiaryHomeScreenContentPreview() {
     DreamdiaryTheme {
         DiaryHomeScreenContent(
-            diaries = diariesPreview,
+            listUIState = DiaryHomeTabListUIState(
+                diaries = diariesPreview,
+            ),
         )
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -125,10 +125,10 @@ private fun DiaryHomeScreenContent(
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 private fun DiaryHomeScreenTopAppBar(
-    modifier: Modifier = Modifier,
     onMenuClick: () -> Unit,
     onNotificationClick: () -> Unit,
     onSearchClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     TopAppBar(
         title = { Text("나의 일기") },

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -31,7 +31,7 @@ import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tabcalendar.DiaryCalendarTab
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.DiaryHomeTabListUIState
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.DiaryListTab
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.diariesPreview
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.diaryHomeTabListUIStatePreview
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
 
 @Composable
@@ -169,9 +169,7 @@ private fun DiaryHomeScreenTopAppBar(
 private fun DiaryHomeScreenContentPreview() {
     DreamdiaryTheme {
         DiaryHomeScreenContent(
-            listUIState = DiaryHomeTabListUIState(
-                diaries = diariesPreview,
-            ),
+            listUIState = diaryHomeTabListUIStatePreview,
         )
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeViewModel.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeViewModel.kt
@@ -3,7 +3,7 @@ package com.boostcamp.dreamteam.dreamdiary.feature.diary.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boostcamp.dreamteam.dreamdiary.core.domain.usecase.GetDiariesUseCase
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.DiaryHomeUIState
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.DiaryHomeTabListUIState
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.toDiaryUi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,13 +15,13 @@ import javax.inject.Inject
 class DiaryHomeViewModel @Inject constructor(
     getDiariesUseCase: GetDiariesUseCase,
 ) : ViewModel() {
-    private val _diaryHomeUIState: MutableStateFlow<DiaryHomeUIState> =
-        MutableStateFlow(DiaryHomeUIState())
-    val diaryHomeUIState = _diaryHomeUIState.asStateFlow()
+    private val _tabListUIState: MutableStateFlow<DiaryHomeTabListUIState> =
+        MutableStateFlow(DiaryHomeTabListUIState())
+    val tabListUIState = _tabListUIState.asStateFlow()
 
     init {
         viewModelScope.launch {
-            _diaryHomeUIState.value = DiaryHomeUIState(
+            _tabListUIState.value = DiaryHomeTabListUIState(
                 diaries = getDiariesUseCase().map { it.toDiaryUi() },
                 loading = false,
             )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeViewModel.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeViewModel.kt
@@ -3,6 +3,7 @@ package com.boostcamp.dreamteam.dreamdiary.feature.diary.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boostcamp.dreamteam.dreamdiary.core.domain.usecase.GetDiariesUseCase
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist.DiaryHomeUIState
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.toDiaryUi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCard.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCard.kt
@@ -26,11 +26,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
-import com.boostcamp.dreamteam.dreamdiary.core.model.Diary
-import com.boostcamp.dreamteam.dreamdiary.core.model.Label
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.toDiaryUi
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.diaryPreview1
 
 @Composable
 internal fun DiaryCard(
@@ -111,30 +109,3 @@ private fun DiaryCardPreview() {
         )
     }
 }
-
-internal val diaryPreview1 = Diary(
-    id = 1,
-    title = "오늘의 일기",
-    content = "오늘은 날씨가 좋았다.",
-    createdAt = "2021-09-01",
-    updatedAt = "2021-09-01",
-    images = emptyList(),
-    labels = listOf(
-        Label("기쁨"),
-        Label("행복"),
-        Label("환희"),
-    ),
-).toDiaryUi()
-
-internal val diaryPreview2 = Diary(
-    id = 2,
-    title = "어제의 일기",
-    content = "어제는 날씨가 좋지 않았다.",
-    createdAt = "2021-08-31",
-    updatedAt = "2021-08-31",
-    images = emptyList(),
-    labels = listOf(
-        Label("슬픔"),
-        Label("우울"),
-    ),
-).toDiaryUi()

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tabcalendar
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.DiaryCalendar
 
 @Composable
 internal fun DiaryCalendarTab(modifier: Modifier = Modifier) {

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryHomeTabListUIState.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryHomeTabListUIState.kt
@@ -2,7 +2,7 @@ package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist
 
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
 
-data class DiaryHomeUIState(
+data class DiaryHomeTabListUIState(
     val diaries: List<DiaryUi> = listOf(),
     val loading: Boolean = false,
 )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryHomeUIState.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryHomeUIState.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.dreamteam.dreamdiary.feature.diary.home
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist
 
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
 

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryListTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryListTab.kt
@@ -17,10 +17,12 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
 
 @Composable
 internal fun DiaryListTab(
-    diaries: List<DiaryUi>,
+    onDiaryClick: (DiaryUi) -> Unit,
     modifier: Modifier = Modifier,
-    onDiaryClick: (DiaryUi) -> Unit = {},
+    uiState: DiaryHomeTabListUIState = DiaryHomeTabListUIState(),
 ) {
+    val (diaries) = uiState
+
     LazyColumn(
         modifier = modifier,
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
@@ -40,7 +42,12 @@ internal fun DiaryListTab(
 @Composable
 private fun DiaryListTabPreview() {
     DreamdiaryTheme {
-        DiaryListTab(diaries = diariesPreview)
+        DiaryListTab(
+            onDiaryClick = { },
+            uiState = DiaryHomeTabListUIState(
+                diaries = diariesPreview,
+            ),
+        )
     }
 }
 

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryListTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryListTab.kt
@@ -11,9 +11,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.DiaryCard
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.diaryPreview1
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.diaryPreview2
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.diariesPreview
 
 @Composable
 internal fun DiaryListTab(
@@ -44,14 +43,11 @@ private fun DiaryListTabPreview() {
     DreamdiaryTheme {
         DiaryListTab(
             onDiaryClick = { },
-            uiState = DiaryHomeTabListUIState(
-                diaries = diariesPreview,
-            ),
+            uiState = diaryHomeTabListUIStatePreview,
         )
     }
 }
 
-internal val diariesPreview = listOf(
-    diaryPreview1,
-    diaryPreview2,
+internal val diaryHomeTabListUIStatePreview = DiaryHomeTabListUIState(
+    diaries = diariesPreview,
 )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryListTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tablist/DiaryListTab.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tablist
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
@@ -10,6 +10,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.DiaryCard
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.diaryPreview1
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.components.diaryPreview2
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.DiaryUi
 
 @Composable

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/models/DiaryUi.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/models/DiaryUi.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.dreamteam.dreamdiary.feature.diary.models
 
 import com.boostcamp.dreamteam.dreamdiary.core.model.Diary
+import com.boostcamp.dreamteam.dreamdiary.core.model.Label
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.vos.DisplayableDateTime
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.models.vos.toDisplayableDateTime
 import java.time.Instant
@@ -26,3 +27,35 @@ internal fun Diary.toDiaryUi(): DiaryUi =
         images = images,
         labels = labels.map { it.toLabelUi() },
     )
+
+internal val diaryPreview1 = Diary(
+    id = 1,
+    title = "오늘의 일기",
+    content = "오늘은 날씨가 좋았다.",
+    createdAt = "2021-09-01",
+    updatedAt = "2021-09-01",
+    images = emptyList(),
+    labels = listOf(
+        Label("기쁨"),
+        Label("행복"),
+        Label("환희"),
+    ),
+).toDiaryUi()
+
+internal val diaryPreview2 = Diary(
+    id = 2,
+    title = "어제의 일기",
+    content = "어제는 날씨가 좋지 않았다.",
+    createdAt = "2021-08-31",
+    updatedAt = "2021-08-31",
+    images = emptyList(),
+    labels = listOf(
+        Label("슬픔"),
+        Label("우울"),
+    ),
+).toDiaryUi()
+
+internal val diariesPreview = listOf(
+    diaryPreview1,
+    diaryPreview2,
+)


### PR DESCRIPTION
close #93 
<!-- ex) close #10, resolves #123 -->

## :man_shrugging: Description

- [x] 탭별로 다른 uiState 클래스를 사용하는 것이 좋을 것 같아 분리했습니다.
- [x] preview의 위치도 수정했습니다

