### PR TITLE
[feat] 꿈일기를 저장할 때 라벨을 함께 저장할 수 있는 기능

### DIFF
--- a/core/data/schemas/com.boostcamp.dreamteam.dreamdiary.core.data.database.DreamDiaryDatabase/1.json
+++ b/core/data/schemas/com.boostcamp.dreamteam.dreamdiary.core.data.database.DreamDiaryDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "55c710c5b13d4a5c2c7517208401c5e1",
+    "identityHash": "faeb53cf060400713976527f3c68305c",
     "entities": [
       {
         "tableName": "diary",
@@ -67,12 +67,62 @@
         },
         "indices": [],
         "foreignKeys": []
+      },
+      {
+        "tableName": "diary_label",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`diaryId` TEXT NOT NULL, `labelId` TEXT NOT NULL, PRIMARY KEY(`diaryId`, `labelId`), FOREIGN KEY(`diaryId`) REFERENCES `diary`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`labelId`) REFERENCES `label`(`label`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "diaryId",
+            "columnName": "diaryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labelId",
+            "columnName": "labelId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "diaryId",
+            "labelId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "diary",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "diaryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "label",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "labelId"
+            ],
+            "referencedColumns": [
+              "label"
+            ]
+          }
+        ]
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '55c710c5b13d4a5c2c7517208401c5e1')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'faeb53cf060400713976527f3c68305c')"
     ]
   }
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/DreamDiaryDatabase.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/DreamDiaryDatabase.kt
@@ -5,9 +5,10 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.dao.DreamDiaryDao
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryLabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
 
-@Database(entities = [DreamDiaryEntity::class, LabelEntity::class], version = 1)
+@Database(entities = [DreamDiaryEntity::class, LabelEntity::class, DreamDiaryLabelEntity::class], version = 1)
 @TypeConverters(value = [InstantTypeConverter::class])
 internal abstract class DreamDiaryDatabase : RoomDatabase() {
     abstract fun dreamDiaryDao(): DreamDiaryDao

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
@@ -2,18 +2,57 @@ package com.boostcamp.dreamteam.dreamdiary.core.data.database.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryLabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
 import kotlinx.coroutines.flow.Flow
+import java.time.Instant
+import java.util.UUID
 
 @Dao
 interface DreamDiaryDao {
     @Insert
     suspend fun insertDreamDiary(dreamDiaryEntity: DreamDiaryEntity)
 
+    @Transaction
+    suspend fun insertDreamDiary(
+        title: String,
+        body: String,
+        labels: List<String>,
+    ) {
+        val dreamDiaryId = UUID.randomUUID().toString()
+        insertDreamDiary(
+            DreamDiaryEntity(
+                id = dreamDiaryId,
+                title = title,
+                body = body,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+            ),
+        )
+        setLabelsToDreamDiary(dreamDiaryId, labels)
+    }
+
     @Insert
     suspend fun insertLabel(labelEntity: LabelEntity)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertLabels(labelEntities: List<LabelEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertDreamDiaryLabels(dreamDiaryEntity: List<DreamDiaryLabelEntity>)
+
+    @Transaction
+    suspend fun setLabelsToDreamDiary(
+        diaryId: String,
+        labels: List<String>,
+    ) {
+        insertLabels(labels.map { LabelEntity(it) })
+        insertDreamDiaryLabels(labels.map { DreamDiaryLabelEntity(diaryId, it) })
+    }
 
     @Query("select * from label where :search is null or label like :search")
     fun getLabels(search: String?): Flow<List<LabelEntity>>

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/DreamDiaryLabelEntity.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/DreamDiaryLabelEntity.kt
@@ -1,0 +1,17 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.database.model
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+
+@Entity(
+    tableName = "diary_label",
+    primaryKeys = ["diaryId", "labelId"],
+    foreignKeys = [
+        ForeignKey(entity = DreamDiaryEntity::class, parentColumns = ["id"], childColumns = ["diaryId"]),
+        ForeignKey(entity = LabelEntity::class, parentColumns = ["label"], childColumns = ["labelId"]),
+    ],
+)
+data class DreamDiaryLabelEntity(
+    val diaryId: String,
+    val labelId: String,
+)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/DefaultDreamDiaryRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/DefaultDreamDiaryRepository.kt
@@ -1,13 +1,10 @@
 package com.boostcamp.dreamteam.dreamdiary.core.data.repository
 
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.dao.DreamDiaryDao
-import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.model.Label
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import java.time.Instant
-import java.util.UUID
 import javax.inject.Inject
 
 internal class DefaultDreamDiaryRepository @Inject constructor(
@@ -16,16 +13,9 @@ internal class DefaultDreamDiaryRepository @Inject constructor(
     override suspend fun addDreamDiary(
         title: String,
         body: String,
+        labels: List<String>,
     ) {
-        dreamDiaryDao.insertDreamDiary(
-            DreamDiaryEntity(
-                id = UUID.randomUUID().toString(),
-                title = title,
-                body = body,
-                createdAt = Instant.now(),
-                updatedAt = Instant.now(),
-            ),
-        )
+        dreamDiaryDao.insertDreamDiary(title, body, labels)
     }
 
     override suspend fun addLabel(label: String) {
@@ -43,5 +33,12 @@ internal class DefaultDreamDiaryRepository @Inject constructor(
             "%$search%"
         }
         return dreamDiaryDao.getLabels(formattedSearch).map { list -> list.map { it.toDomain() } }
+    }
+
+    override suspend fun addDreamDiaryLabel(
+        diaryId: String,
+        labels: List<String>,
+    ) {
+        dreamDiaryDao.setLabelsToDreamDiary(diaryId, labels)
     }
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/DreamDiaryRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/DreamDiaryRepository.kt
@@ -7,9 +7,15 @@ interface DreamDiaryRepository {
     suspend fun addDreamDiary(
         title: String,
         body: String,
+        labels: List<String>,
     )
 
     suspend fun addLabel(label: String)
 
     fun getLabels(search: String): Flow<List<Label>>
+
+    suspend fun addDreamDiaryLabel(
+        diaryId: String,
+        labels: List<String>,
+    )
 }

--- a/core/domain/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/domain/usecase/AddDreamDiaryUseCase.kt
+++ b/core/domain/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/domain/usecase/AddDreamDiaryUseCase.kt
@@ -9,7 +9,8 @@ class AddDreamDiaryUseCase @Inject constructor(
     suspend operator fun invoke(
         title: String,
         body: String,
+        labels: List<String> = listOf(),
     ) {
-        dreamDiaryRepository.addDreamDiary(title, body)
+        dreamDiaryRepository.addDreamDiary(title, body, labels)
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
@@ -70,8 +70,9 @@ class DiaryWriteViewModel @Inject constructor(
     fun addDreamDiary() {
         val title = _uiState.value.title
         val content = _uiState.value.content
+        val labels = _uiState.value.selectableLabels.map { it.label.name }
         viewModelScope.launch {
-            addDreamDiaryUseCase(title, content)
+            addDreamDiaryUseCase(title, content, labels)
             _event.trySend(DiaryWriteEvent.DiaryAddSuccess)
         }
     }


### PR DESCRIPTION
#73 

## :man_shrugging: Description

꿈일기를 저장할 때 체크해 둔 라벨을 함께 저장합니다.
- 꿈일기와 라벨의 관계를 나타내는 n:n 엔티티를 생성했습니다.
