### PR TITLE
fix: 기본 Locale을 가져오는 방식 수정

### DIFF
--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendar.kt
@@ -27,7 +27,8 @@ import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import java.time.YearMonth
 import java.time.format.TextStyle
-import java.util.Locale
+import androidx.compose.ui.text.intl.Locale.Companion as ComposeLocale
+import java.util.Locale as JavaLocale
 
 /*
 * TODO
@@ -76,6 +77,7 @@ private fun DiaryCalendarHeader(
     modifier: Modifier = Modifier,
     onMonthTextClick: () -> Unit = { },
     today: YearMonth = YearMonth.now(),
+    locale: JavaLocale = ComposeLocale.current.platformLocale,
 ) {
     Row(
         modifier = modifier,
@@ -94,7 +96,7 @@ private fun DiaryCalendarHeader(
                 verticalAlignment = Alignment.Bottom,
             ) {
                 Text(
-                    text = yearMonth.month.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                    text = yearMonth.month.getDisplayName(TextStyle.SHORT, locale),
                     color = MaterialTheme.colorScheme.onSurface,
                     style = MaterialTheme.typography.titleLarge,
                 )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarBody.kt
@@ -26,13 +26,14 @@ import java.time.format.TextStyle
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
 import java.time.temporal.WeekFields
-import java.util.Locale
+import androidx.compose.ui.text.intl.Locale as ComposeLocale
+import java.util.Locale as JavaLocale
 
 @Composable
 internal fun DiaryCalendarBody(
     yearMonth: YearMonth,
     modifier: Modifier = Modifier,
-    locale: Locale = Locale.getDefault(),
+    locale: JavaLocale = ComposeLocale.current.platformLocale,
 ) {
     val firstDayOfMonth = yearMonth.atDay(1)
     val lastDayOfMonth = yearMonth.atEndOfMonth()
@@ -63,7 +64,7 @@ internal fun DiaryCalendarBody(
 @Composable
 private fun WeekHeader(
     modifier: Modifier = Modifier,
-    locale: Locale = Locale.getDefault(),
+    locale: JavaLocale = ComposeLocale.current.platformLocale,
 ) {
     val reorderedDays = (0 until 7).map { (it + 6) % 7 + 1 }
 

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarYearMonthPicker.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/components/DiaryCalendarYearMonthPicker.kt
@@ -37,7 +37,8 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import java.time.Month
 import java.time.YearMonth
 import java.time.format.TextStyle
-import java.util.Locale
+import androidx.compose.ui.text.intl.Locale as ComposeLocale
+import java.util.Locale as JavaLocale
 
 @Composable
 internal fun YearMonthPicker(
@@ -145,7 +146,7 @@ private fun YearMonthPickerBody(
     selectedYearMonth: YearMonth,
     onYearMonthClick: (YearMonth) -> Unit,
     modifier: Modifier = Modifier,
-    locale: Locale = Locale.getDefault(),
+    locale: JavaLocale = ComposeLocale.current.platformLocale,
     currentYearMonth: YearMonth = YearMonth.now(),
 ) {
     val yearMonths = Month.entries.map { YearMonth.of(showingYear, it) }


### PR DESCRIPTION
<!-- ex) close #10, resolves #123 -->

## :man_shrugging: Description

- [x] java.util.Locale의 default 대신 androidx.compose.ui.text.intl.Locale의 current 사용
