### PR TITLE
[feat] bottom sheet에 일기 목록 표시

### DIFF
--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -127,6 +127,7 @@ private fun DiaryHomeScreenContent(
                 )
 
                 1 -> DiaryCalendarTab(
+                    onDiaryClick = onDiaryClick,
                     onYearMothChange = onCalendarYearMothChange,
                     modifier = tabModifier,
                     state = calendarUIState,

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendar.kt
@@ -29,7 +29,6 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diariesPreview
 import java.time.LocalDate
 import java.time.YearMonth
-import java.time.ZonedDateTime
 import java.time.format.TextStyle
 import java.util.Locale
 

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendar.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendar.kt
@@ -27,13 +27,16 @@ import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diariesPreview
+import java.time.LocalDate
 import java.time.YearMonth
+import java.time.ZonedDateTime
 import java.time.format.TextStyle
 import java.util.Locale
 
 @Composable
 internal fun DiaryCalendar(
     diariesOfMonth: List<DiaryUi>,
+    onDayClick: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
     yearMonth: YearMonth = YearMonth.now(),
     onYearMothChange: (YearMonth) -> Unit = { },
@@ -63,6 +66,7 @@ internal fun DiaryCalendar(
 
         DiaryCalendarBody(
             diariesOfMonth = diariesOfMonth,
+            onDayClick = onDayClick,
             yearMonth = yearMonth,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -131,6 +135,7 @@ private fun DiaryCalendarPreview() {
         DiaryCalendar(
             diariesOfMonth = diariesPreview,
             yearMonth = YearMonth.now(),
+            onDayClick = { },
         )
     }
 }
@@ -142,6 +147,7 @@ private fun DiaryCalendarPreview1() {
         DiaryCalendar(
             diariesOfMonth = diariesPreview,
             yearMonth = YearMonth.of(2024, 1),
+            onDayClick = { },
         )
     }
 }
@@ -153,6 +159,7 @@ private fun DiaryCalendarPreview2() {
         DiaryCalendar(
             diariesOfMonth = diariesPreview,
             yearMonth = YearMonth.of(2024, 2),
+            onDayClick = { },
         )
     }
 }
@@ -164,6 +171,7 @@ private fun DiaryCalendarPreview3() {
         DiaryCalendar(
             diariesOfMonth = diariesPreview,
             yearMonth = YearMonth.of(2024, 3),
+            onDayClick = { },
         )
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBody.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBody.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -37,8 +38,9 @@ import java.util.Locale
 @Composable
 internal fun DiaryCalendarBody(
     diariesOfMonth: List<DiaryUi>,
-    yearMonth: YearMonth,
+    onDayClick: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
+    yearMonth: YearMonth = YearMonth.now(),
     locale: Locale = Locale.getDefault(),
 ) {
     val firstDayOfMonth = yearMonth.atDay(1)
@@ -62,6 +64,7 @@ internal fun DiaryCalendarBody(
                 diariesOfWeek = diariesOfMonth.diariesOfWeek(firstDateOfWeek),
                 currentYearMonth = yearMonth,
                 firstDateOfWeek = firstDateOfWeek,
+                onDayClick = onDayClick,
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -101,6 +104,7 @@ private fun WeekRow(
     diariesOfWeek: List<DiaryUi>,
     currentYearMonth: YearMonth,
     firstDateOfWeek: LocalDate,
+    onDayClick: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val daysOfWeek = (0 until 7).map { firstDateOfWeek.plusDays(it.toLong()) }
@@ -110,7 +114,9 @@ private fun WeekRow(
     Row(modifier = modifier) {
         dayToDiaryMap.forEach { (date, diaries) ->
             DayCell(
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { onDayClick(date) },
                 isToday = date == LocalDate.now(),
             ) {
                 BadgedBox(
@@ -176,6 +182,7 @@ private fun CalendarBodyPreview() {
     DreamdiaryTheme {
         DiaryCalendarBody(
             diariesOfMonth = diariesPreview,
+            onDayClick = { },
             yearMonth = YearMonth.now(),
         )
     }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
@@ -1,0 +1,42 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryUi
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diaryPreview1
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DiaryCalendarBottomSheet(
+    diariesOfDay: List<DiaryUi>,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val bottomSheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = bottomSheetState
+    ) {
+    }
+}
+
+@Preview
+@Composable
+private fun DiaryCalendarBottomSheetPreview() {
+    DreamdiaryTheme {
+        DiaryCalendarBottomSheet(
+            diariesOfDay = listOf(diaryPreview1),
+            onDismissRequest = { /* no-op */ },
+        )
+    }
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,6 +44,7 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diaryPreview2
 @Composable
 internal fun DiaryCalendarBottomSheet(
     diariesOfDay: List<DiaryUi>,
+    onDiaryClick: (DiaryUi) -> Unit,
     onDismissRequest: () -> Unit,
     onBackClick: () -> Unit,
     onForwardClick: () -> Unit,
@@ -57,12 +59,14 @@ internal fun DiaryCalendarBottomSheet(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
-        sheetState = bottomSheetState
+        sheetState = bottomSheetState,
     ) {
         BottomSheetHeader(
             onBackClick = onBackClick,
             onForwardClick = onForwardClick,
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
         )
         when {
             diariesOfDay.isEmpty() -> {
@@ -70,7 +74,11 @@ internal fun DiaryCalendarBottomSheet(
             }
 
             else -> {
-                ListBottomSheet(diariesOfDay = diariesOfDay, modifier = Modifier.fillMaxSize())
+                ListBottomSheet(
+                    diariesOfDay = diariesOfDay,
+                    onDiaryClick = onDiaryClick,
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
         }
     }
@@ -87,7 +95,7 @@ private fun BottomSheetHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         IconButton(
-            onClick = onBackClick
+            onClick = onBackClick,
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.ArrowBackIos,
@@ -95,7 +103,7 @@ private fun BottomSheetHeader(
             )
         }
         IconButton(
-            onClick = onForwardClick
+            onClick = onForwardClick,
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.ArrowForwardIos,
@@ -132,19 +140,24 @@ private fun EmptyBottomSheet(modifier: Modifier = Modifier) {
         Spacer(
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f)
+                .weight(1f),
         )
     }
 }
 
 @Composable
-private fun ListBottomSheet(diariesOfDay: List<DiaryUi>, modifier: Modifier = Modifier) {
+private fun ListBottomSheet(
+    diariesOfDay: List<DiaryUi>,
+    onDiaryClick: (DiaryUi) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     LazyColumn(modifier = modifier) {
         items(diariesOfDay) { diary: DiaryUi ->
             ListItem(
                 headlineContent = {
                     Text(text = diary.title)
                 },
+                modifier = Modifier.clickable { onDiaryClick(diary) },
                 overlineContent = {
                     Text(text = diary.sortKey.formatted)
                 },
@@ -152,7 +165,7 @@ private fun ListBottomSheet(diariesOfDay: List<DiaryUi>, modifier: Modifier = Mo
                     Text(text = diary.content, maxLines = 2, overflow = TextOverflow.Ellipsis)
                 },
                 colors = ListItemDefaults.colors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
                 ),
             )
             Spacer(modifier = Modifier.height(1.dp))
@@ -167,6 +180,7 @@ private fun DiaryCalendarBottomSheetPreviewList() {
     DreamdiaryTheme {
         DiaryCalendarBottomSheet(
             diariesOfDay = listOf(diaryPreview1, diaryPreview2),
+            onDiaryClick = { /* no-op */ },
             onDismissRequest = { /* no-op */ },
             onBackClick = { /* no-op */ },
             onForwardClick = { /* no-op */ },
@@ -182,6 +196,7 @@ private fun DiaryCalendarBottomSheetPreviewEmpty() {
     DreamdiaryTheme {
         DiaryCalendarBottomSheet(
             diariesOfDay = emptyList(),
+            onDiaryClick = { /* no-op */ },
             onDismissRequest = { /* no-op */ },
             onBackClick = { /* no-op */ },
             onForwardClick = { /* no-op */ },

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
@@ -1,17 +1,38 @@
 package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.NightsStay
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diaryPreview1
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diaryPreview2
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -19,24 +40,107 @@ internal fun DiaryCalendarBottomSheet(
     diariesOfDay: List<DiaryUi>,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
+    initialSheetValue: SheetValue = SheetValue.Hidden,
 ) {
-    val bottomSheetState = rememberModalBottomSheetState()
+    val bottomSheetState = rememberStandardBottomSheetState(
+        initialValue = initialSheetValue,
+        skipHiddenState = false,
+    )
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
         sheetState = bottomSheetState
     ) {
+        when {
+            diariesOfDay.isEmpty() -> {
+                EmptyBottomSheet(modifier = Modifier.fillMaxSize())
+            }
+
+            else -> {
+                ListBottomSheet(diariesOfDay = diariesOfDay, modifier = Modifier.fillMaxSize())
+            }
+        }
     }
 }
 
-@Preview
 @Composable
-private fun DiaryCalendarBottomSheetPreview() {
+private fun EmptyBottomSheet(modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Icon(
+                    imageVector = Icons.Outlined.NightsStay,
+                    contentDescription = "Empty Diary",
+                    modifier = Modifier.size(56.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = stringResource(R.string.calendar_no_diary),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+            }
+        }
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun ListBottomSheet(diariesOfDay: List<DiaryUi>, modifier: Modifier = Modifier) {
+    LazyColumn(modifier = modifier) {
+        items(diariesOfDay) { diary: DiaryUi ->
+            ListItem(
+                headlineContent = {
+                    Text(text = diary.title)
+                },
+                overlineContent = {
+                    Text(text = diary.sortKey.formatted)
+                },
+                supportingContent = {
+                    Text(text = diary.content, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                },
+                colors = ListItemDefaults.colors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+                ),
+            )
+            Spacer(modifier = Modifier.height(1.dp))
+        }
+    }
+}
+
+@ExperimentalMaterial3Api
+@PreviewLightDark
+@Composable
+private fun DiaryCalendarBottomSheetPreviewList() {
     DreamdiaryTheme {
         DiaryCalendarBottomSheet(
-            diariesOfDay = listOf(diaryPreview1),
+            diariesOfDay = listOf(diaryPreview1, diaryPreview2),
             onDismissRequest = { /* no-op */ },
+            initialSheetValue = SheetValue.Expanded,
+        )
+    }
+}
+
+@ExperimentalMaterial3Api
+@PreviewLightDark
+@Composable
+private fun DiaryCalendarBottomSheetPreviewEmpty() {
+    DreamdiaryTheme {
+        DiaryCalendarBottomSheet(
+            diariesOfDay = emptyList(),
+            onDismissRequest = { /* no-op */ },
+            initialSheetValue = SheetValue.Expanded,
         )
     }
 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
@@ -1,18 +1,24 @@
 package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBackIos
+import androidx.compose.material.icons.automirrored.outlined.ArrowForwardIos
 import androidx.compose.material.icons.outlined.NightsStay
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
@@ -25,7 +31,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
@@ -39,6 +44,8 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diaryPreview2
 internal fun DiaryCalendarBottomSheet(
     diariesOfDay: List<DiaryUi>,
     onDismissRequest: () -> Unit,
+    onBackClick: () -> Unit,
+    onForwardClick: () -> Unit,
     modifier: Modifier = Modifier,
     initialSheetValue: SheetValue = SheetValue.Hidden,
 ) {
@@ -52,6 +59,11 @@ internal fun DiaryCalendarBottomSheet(
         modifier = modifier,
         sheetState = bottomSheetState
     ) {
+        BottomSheetHeader(
+            onBackClick = onBackClick,
+            onForwardClick = onForwardClick,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        )
         when {
             diariesOfDay.isEmpty() -> {
                 EmptyBottomSheet(modifier = Modifier.fillMaxSize())
@@ -60,6 +72,35 @@ internal fun DiaryCalendarBottomSheet(
             else -> {
                 ListBottomSheet(diariesOfDay = diariesOfDay, modifier = Modifier.fillMaxSize())
             }
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetHeader(
+    onBackClick: () -> Unit,
+    onForwardClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        IconButton(
+            onClick = onBackClick
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ArrowBackIos,
+                contentDescription = stringResource(R.string.calendar_yesterday),
+            )
+        }
+        IconButton(
+            onClick = onForwardClick
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ArrowForwardIos,
+                contentDescription = stringResource(R.string.calendar_tomorrow),
+            )
         }
     }
 }
@@ -127,6 +168,8 @@ private fun DiaryCalendarBottomSheetPreviewList() {
         DiaryCalendarBottomSheet(
             diariesOfDay = listOf(diaryPreview1, diaryPreview2),
             onDismissRequest = { /* no-op */ },
+            onBackClick = { /* no-op */ },
+            onForwardClick = { /* no-op */ },
             initialSheetValue = SheetValue.Expanded,
         )
     }
@@ -140,6 +183,8 @@ private fun DiaryCalendarBottomSheetPreviewEmpty() {
         DiaryCalendarBottomSheet(
             diariesOfDay = emptyList(),
             onDismissRequest = { /* no-op */ },
+            onBackClick = { /* no-op */ },
+            onForwardClick = { /* no-op */ },
             initialSheetValue = SheetValue.Expanded,
         )
     }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component.DiaryCalendar
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component.DiaryCalendarBottomSheet
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diariesPreview
 import java.time.LocalDate
 import java.time.YearMonth
@@ -24,6 +25,7 @@ import java.time.ZonedDateTime
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DiaryCalendarTab(
+    onDiaryClick: (DiaryUi) -> Unit,
     onYearMothChange: (YearMonth) -> Unit,
     modifier: Modifier = Modifier,
     state: DiaryHomeTabCalendarUIState = DiaryHomeTabCalendarUIState(),
@@ -37,12 +39,20 @@ internal fun DiaryCalendarTab(
             modifier = Modifier.padding(horizontal = 16.dp),
             yearMonth = state.yearMonth,
             onYearMothChange = onYearMothChange,
-            onDayClick = { lastSelectedDay = it; isBottomSheetOpen = true },
+            onDayClick = {
+                lastSelectedDay = it
+                isBottomSheetOpen = true
+            },
         )
 
         if (isBottomSheetOpen) {
             DiaryCalendarBottomSheet(
-                diariesOfDay = state.diariesOfMonth.filter { it.sortKey.value.toLocalDate().isEqual(lastSelectedDay) },
+                diariesOfDay = state.diariesOfMonth.filter {
+                    it.sortKey.value
+                        .toLocalDate()
+                        .isEqual(lastSelectedDay)
+                },
+                onDiaryClick = onDiaryClick,
                 onDismissRequest = { isBottomSheetOpen = false },
                 onBackClick = { lastSelectedDay = lastSelectedDay.minusDays(1) },
                 onForwardClick = { lastSelectedDay = lastSelectedDay.plusDays(1) },
@@ -57,6 +67,7 @@ internal fun DiaryCalendarTab(
 private fun DiaryCalendarTabPreview() {
     DreamdiaryTheme {
         DiaryCalendarTab(
+            onDiaryClick = { /* no-op */ },
             onYearMothChange = { },
             modifier = Modifier.fillMaxWidth(),
         )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
@@ -3,6 +3,7 @@ package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tabcalendar
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,6 +21,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 import java.time.ZonedDateTime
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DiaryCalendarTab(
     onYearMothChange: (YearMonth) -> Unit,

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
@@ -44,6 +44,8 @@ internal fun DiaryCalendarTab(
             DiaryCalendarBottomSheet(
                 diariesOfDay = state.diariesOfMonth.filter { it.sortKey.value.toLocalDate().isEqual(lastSelectedDay) },
                 onDismissRequest = { isBottomSheetOpen = false },
+                onBackClick = { lastSelectedDay = lastSelectedDay.minusDays(1) },
+                onForwardClick = { lastSelectedDay = lastSelectedDay.plusDays(1) },
                 modifier = Modifier.fillMaxSize(),
             )
         }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/tabcalendar/DiaryCalendarTab.kt
@@ -1,16 +1,24 @@
 package com.boostcamp.dreamteam.dreamdiary.feature.diary.home.tabcalendar
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component.DiaryCalendar
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.component.DiaryCalendarBottomSheet
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diariesPreview
+import java.time.LocalDate
 import java.time.YearMonth
+import java.time.ZonedDateTime
 
 @Composable
 internal fun DiaryCalendarTab(
@@ -18,13 +26,25 @@ internal fun DiaryCalendarTab(
     modifier: Modifier = Modifier,
     state: DiaryHomeTabCalendarUIState = DiaryHomeTabCalendarUIState(),
 ) {
+    var lastSelectedDay: LocalDate by rememberSaveable { mutableStateOf(ZonedDateTime.now().toLocalDate()) }
+    var isBottomSheetOpen by rememberSaveable { mutableStateOf(false) }
+
     Surface(modifier = modifier) {
         DiaryCalendar(
             diariesOfMonth = state.diariesOfMonth,
             modifier = Modifier.padding(horizontal = 16.dp),
             yearMonth = state.yearMonth,
             onYearMothChange = onYearMothChange,
+            onDayClick = { lastSelectedDay = it; isBottomSheetOpen = true },
         )
+
+        if (isBottomSheetOpen) {
+            DiaryCalendarBottomSheet(
+                diariesOfDay = state.diariesOfMonth.filter { it.sortKey.value.toLocalDate().isEqual(lastSelectedDay) },
+                onDismissRequest = { isBottomSheetOpen = false },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
     }
 }
 

--- a/feature/diary/src/main/res/values/strings.xml
+++ b/feature/diary/src/main/res/values/strings.xml
@@ -24,4 +24,5 @@
     <string name="calendar_today">오늘</string>
     <string name="calendar_cancel">취소</string>
     <string name="calendar_ok">확인</string>
+    <string name="calendar_no_diary">일기가 없습니다</string>
 </resources>

--- a/feature/diary/src/main/res/values/strings.xml
+++ b/feature/diary/src/main/res/values/strings.xml
@@ -25,4 +25,6 @@
     <string name="calendar_cancel">취소</string>
     <string name="calendar_ok">확인</string>
     <string name="calendar_no_diary">일기가 없습니다</string>
+    <string name="calendar_yesterday">어제로 이동</string>
+    <string name="calendar_tomorrow">내일로 이동</string>
 </resources>


### PR DESCRIPTION
## :man_shrugging: Description

Added calendar bottom sheet functionality to display diary entries for selected dates. The bottom sheet includes:
- Empty state UI when no diary entries exist for the selected date
- List view of diary entries showing title, date, and content preview
- Navigation buttons to move between days
- Click handling on calendar days to show the bottom sheet
- Localized strings for navigation and empty states

The calendar component now supports day selection and maintains the selected date state, enabling users to browse through their diary entries chronologically.

## :camera: Screenshots

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/V7Nro4q38LpbdkXBzUCW/f07c9edb-a756-415f-8593-988d32f21e37.png)
