### PR TITLE
[fix] 라벨 검색 시 버그 수정

### DIFF
--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/model/LabelUi.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/model/LabelUi.kt
@@ -10,3 +10,14 @@ internal fun Label.toLabelUi() =
     LabelUi(
         name = name,
     )
+
+internal val filteredLabelsPreview = listOf(
+    LabelUi("악몽"),
+    LabelUi("개꿈"),
+    LabelUi("귀신"),
+)
+
+internal val selectedLabelsPreview = setOf(
+    LabelUi("악몽"),
+    LabelUi("공룡"),
+)

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
@@ -33,7 +33,6 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.component.DiaryWri
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.component.DiaryWriteScreenHeader
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.DiaryWriteEvent
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.LabelAddFailureReason
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.SelectableLabel
 import kotlinx.coroutines.flow.collectLatest
 import java.time.ZonedDateTime
 
@@ -44,7 +43,13 @@ fun DiaryWriteScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    val (title, content, searchValue, selectableLabels, sleepEndAt, sleepStartAt) = uiState
+    val title = uiState.title
+    val content = uiState.content
+    val labelFilter = uiState.labelFilter
+    val filteredLabels = uiState.filteredLabels
+    val selectedLabels = uiState.selectedLabels
+    val sleepStartAt = uiState.sleepStartAt
+    val sleepEndAt = uiState.sleepEndAt
 
     val context = LocalContext.current
 
@@ -86,12 +91,13 @@ fun DiaryWriteScreen(
         DiaryWriteScreen(
             title = title,
             content = content,
-            searchValue = searchValue,
-            selectableLabels = selectableLabels,
+            labelFilter = labelFilter,
+            filteredLabels = filteredLabels,
+            selectedLabels = selectedLabels,
             onTitleChange = viewModel::setTitle,
             onContentChange = viewModel::setContent,
             onCheckChange = viewModel::toggleLabel,
-            onSearchValueChange = viewModel::setSearchValue,
+            onLabelFilterChange = viewModel::setLabelFilter,
             onClickLabelSave = viewModel::addLabel,
             sleepStartAt = sleepStartAt,
             onSleepStartAtChange = viewModel::setSleepStartAt,
@@ -106,12 +112,13 @@ fun DiaryWriteScreen(
 private fun DiaryWriteScreen(
     title: String,
     content: String,
-    searchValue: String,
-    selectableLabels: List<SelectableLabel>,
+    labelFilter: String,
+    filteredLabels: List<LabelUi>,
+    selectedLabels: Set<LabelUi>,
     onTitleChange: (String) -> Unit,
     onContentChange: (String) -> Unit,
     onCheckChange: (labelUi: LabelUi) -> Unit,
-    onSearchValueChange: (String) -> Unit,
+    onLabelFilterChange: (String) -> Unit,
     onClickLabelSave: () -> Unit,
     sleepStartAt: ZonedDateTime,
     onSleepStartAtChange: (ZonedDateTime) -> Unit,
@@ -127,9 +134,10 @@ private fun DiaryWriteScreen(
             .verticalScroll(scrollState),
     ) {
         DiaryWriteScreenHeader(
-            searchValue = searchValue,
-            onSearchValueChange = onSearchValueChange,
-            selectableLabels = selectableLabels,
+            labelFilter = labelFilter,
+            onLabelFilterChange = onLabelFilterChange,
+            filteredLabels = filteredLabels,
+            selectedLabels = selectedLabels,
             sleepStartAt = sleepStartAt,
             sleepEndAt = sleepEndAt,
             onSleepStartAtChange = onSleepStartAtChange,
@@ -184,17 +192,21 @@ private fun PreviewDiaryListScreen() {
         DiaryWriteScreen(
             title = "",
             content = "",
-            searchValue = "",
-            selectableLabels = listOf(
-                SelectableLabel(LabelUi("악몽"), isSelected = true),
-                SelectableLabel(LabelUi("개꿈"), isSelected = false),
-                SelectableLabel(LabelUi("귀신"), isSelected = false),
+            labelFilter = "",
+            filteredLabels = listOf(
+                LabelUi("악몽"),
+                LabelUi("개꿈"),
+                LabelUi("귀신"),
+            ),
+            selectedLabels = setOf(
+                LabelUi("악몽"),
+                LabelUi("공룡"),
             ),
             onTitleChange = {},
             onContentChange = {},
             onCheckChange = {},
             onClickLabelSave = {},
-            onSearchValueChange = {},
+            onLabelFilterChange = {},
             sleepStartAt = ZonedDateTime.now(),
             onSleepStartAtChange = {},
             sleepEndAt = ZonedDateTime.now(),

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
@@ -29,6 +29,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.filteredLabelsPreview
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.selectedLabelsPreview
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.component.DiaryWriteScreenBody
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.component.DiaryWriteScreenHeader
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.DiaryWriteEvent
@@ -193,15 +195,8 @@ private fun PreviewDiaryListScreen() {
             title = "",
             content = "",
             labelFilter = "",
-            filteredLabels = listOf(
-                LabelUi("악몽"),
-                LabelUi("개꿈"),
-                LabelUi("귀신"),
-            ),
-            selectedLabels = setOf(
-                LabelUi("악몽"),
-                LabelUi("공룡"),
-            ),
+            filteredLabels = filteredLabelsPreview,
+            selectedLabels = selectedLabelsPreview,
             onTitleChange = {},
             onContentChange = {},
             onCheckChange = {},

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
@@ -64,7 +64,7 @@ class DiaryWriteViewModel @Inject constructor(
                     } else {
                         add(labelUi)
                     }
-                }
+                },
             )
         }
     }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
@@ -126,8 +126,8 @@ class DiaryWriteViewModel @Inject constructor(
                 _uiState.subscriptionCount,
                 SharingStarted.WhileSubscribed(5000L),
             ).collect { labels ->
-                _uiState.update {
-                    it.copy(
+                _uiState.update { uiState ->
+                    uiState.copy(
                         filteredLabels = labels.map { it.toLabelUi() },
                     )
                 }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
@@ -11,7 +11,6 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.toLabelUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.DiaryWriteEvent
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.DiaryWriteUiState
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.LabelAddFailureReason
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.SelectableLabel
 import com.boostcamp.dreamteam.dreamdiary.feature.flowWithStarted
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -52,26 +51,22 @@ class DiaryWriteViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(content = content)
     }
 
-    fun setSearchValue(searchValue: String) {
-        _uiState.value = _uiState.value.copy(searchValue = searchValue)
+    fun setLabelFilter(labelFilter: String) {
+        _uiState.value = _uiState.value.copy(labelFilter = labelFilter)
     }
 
     fun toggleLabel(labelUi: LabelUi) {
-        _uiState.value = _uiState.value.copy(
-            selectableLabels = _uiState.value.selectableLabels.map {
-                if (it.label.name == labelUi.name) {
-                    it.copy(isSelected = !it.isSelected)
-                } else {
-                    it
-                }
-            },
-        )
+        _uiState.update {
+            it.copy(
+                selectedLabels = it.selectedLabels.toMutableSet().apply { add(labelUi) },
+            )
+        }
     }
 
     fun addDreamDiary() {
         val title = _uiState.value.title
         val content = _uiState.value.content
-        val labels = _uiState.value.selectableLabels.map { it.label.name }
+        val labels = _uiState.value.selectedLabels.map { it.name }
         val sleepStartAt = _uiState.value.sleepStartAt
         val sleepEndAt = _uiState.value.sleepEndAt
         viewModelScope.launch {
@@ -87,7 +82,7 @@ class DiaryWriteViewModel @Inject constructor(
     }
 
     fun addLabel() {
-        val addLabel = _uiState.value.searchValue
+        val addLabel = _uiState.value.labelFilter
         viewModelScope.launch {
             try {
                 addLabelUseCase(addLabel)
@@ -120,24 +115,15 @@ class DiaryWriteViewModel @Inject constructor(
     private fun collectLabels() {
         viewModelScope.launch {
             _uiState.flatMapLatest {
-                getLabelsUseCase(it.searchValue)
+                getLabelsUseCase(it.labelFilter)
             }.flowWithStarted(
                 _uiState.subscriptionCount,
                 SharingStarted.WhileSubscribed(5000L),
             ).collect { labels ->
-                _uiState.update { prevUiState ->
-                    val newSelectableLabels = mutableListOf<SelectableLabel>()
-                    for (label in labels) {
-                        var newSelectableLabel = SelectableLabel(label.toLabelUi(), false)
-                        for (selectableLabel in prevUiState.selectableLabels) {
-                            if (label.name == selectableLabel.label.name) {
-                                newSelectableLabel = newSelectableLabel.copy(isSelected = selectableLabel.isSelected)
-                                break
-                            }
-                        }
-                        newSelectableLabels.add(newSelectableLabel)
-                    }
-                    prevUiState.copy(selectableLabels = newSelectableLabels)
+                _uiState.update {
+                    it.copy(
+                        filteredLabels = labels.map { it.toLabelUi() },
+                    )
                 }
             }
         }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteViewModel.kt
@@ -58,7 +58,13 @@ class DiaryWriteViewModel @Inject constructor(
     fun toggleLabel(labelUi: LabelUi) {
         _uiState.update {
             it.copy(
-                selectedLabels = it.selectedLabels.toMutableSet().apply { add(labelUi) },
+                selectedLabels = it.selectedLabels.toMutableSet().apply {
+                    if (contains(labelUi)) {
+                        remove(labelUi)
+                    } else {
+                        add(labelUi)
+                    }
+                }
             )
         }
     }

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/DiaryWriteScreenHeader.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/DiaryWriteScreenHeader.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.SelectableLabel
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -52,9 +51,10 @@ import java.util.Locale
 
 @Composable
 internal fun DiaryWriteScreenHeader(
-    searchValue: String,
-    onSearchValueChange: (String) -> Unit,
-    selectableLabels: List<SelectableLabel>,
+    labelFilter: String,
+    onLabelFilterChange: (String) -> Unit,
+    filteredLabels: List<LabelUi>,
+    selectedLabels: Set<LabelUi>,
     sleepStartAt: ZonedDateTime,
     sleepEndAt: ZonedDateTime,
     onSleepStartAtChange: (ZonedDateTime) -> Unit,
@@ -89,10 +89,10 @@ internal fun DiaryWriteScreenHeader(
                 contentDescription = stringResource(R.string.write_category),
             )
             Text(
-                text = if (selectableLabels.isEmpty()) {
+                text = if (selectedLabels.isEmpty()) {
                     stringResource(R.string.write_no_label)
                 } else {
-                    selectableLabels.filter { it.isSelected }.joinToString { it.label.name }
+                    selectedLabels.joinToString { it.name }
                 },
                 modifier = Modifier.fillMaxWidth(),
                 maxLines = 1,
@@ -102,9 +102,10 @@ internal fun DiaryWriteScreenHeader(
         if (isLabelSelectionDialogOpen) {
             LabelSelectionDialog(
                 onDismissRequest = { isLabelSelectionDialogOpen = false },
-                searchValue = searchValue,
-                onSearchValueChange = onSearchValueChange,
-                selectableLabels = selectableLabels,
+                labelFilter = labelFilter,
+                onLabelFilterChange = onLabelFilterChange,
+                filteredLabels = filteredLabels,
+                selectedLabels = selectedLabels,
                 onCheckChange = onCheckChange,
                 onClickLabelSave = onClickLabelSave,
                 modifier = Modifier.width(400.dp),
@@ -287,9 +288,17 @@ private fun DateHeader(
 private fun DiaryWriteScreenHeaderPreview() {
     DreamdiaryTheme {
         DiaryWriteScreenHeader(
-            searchValue = "",
-            onSearchValueChange = { },
-            selectableLabels = emptyList(),
+            labelFilter = "",
+            onLabelFilterChange = { },
+            filteredLabels = listOf(
+                LabelUi("악몽"),
+                LabelUi("개꿈"),
+                LabelUi("귀신"),
+            ),
+            selectedLabels = setOf(
+                LabelUi("악몽"),
+                LabelUi("공룡"),
+            ),
             sleepStartAt = ZonedDateTime.now(),
             sleepEndAt = ZonedDateTime.now(),
             onSleepStartAtChange = { },

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/DiaryWriteScreenHeader.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/DiaryWriteScreenHeader.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.filteredLabelsPreview
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.selectedLabelsPreview
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -290,15 +292,8 @@ private fun DiaryWriteScreenHeaderPreview() {
         DiaryWriteScreenHeader(
             labelFilter = "",
             onLabelFilterChange = { },
-            filteredLabels = listOf(
-                LabelUi("악몽"),
-                LabelUi("개꿈"),
-                LabelUi("귀신"),
-            ),
-            selectedLabels = setOf(
-                LabelUi("악몽"),
-                LabelUi("공룡"),
-            ),
+            filteredLabels = filteredLabelsPreview,
+            selectedLabels = selectedLabelsPreview,
             sleepStartAt = ZonedDateTime.now(),
             sleepEndAt = ZonedDateTime.now(),
             onSleepStartAtChange = { },

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/LabelSelectionDialog.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/LabelSelectionDialog.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.window.Dialog
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.filteredLabelsPreview
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.selectedLabelsPreview
 
 @Composable
 internal fun LabelSelectionDialog(
@@ -128,15 +130,8 @@ private fun LabelSelectionDialogPreview() {
             labelFilter = "",
             onLabelFilterChange = {},
             onCheckChange = {},
-            filteredLabels = listOf(
-                LabelUi("악몽"),
-                LabelUi("개꿈"),
-                LabelUi("귀신"),
-            ),
-            selectedLabels = setOf(
-                LabelUi("악몽"),
-                LabelUi("공룡"),
-            ),
+            filteredLabels = filteredLabelsPreview,
+            selectedLabels = selectedLabelsPreview,
             onClickLabelSave = {},
             modifier = Modifier.width(400.dp),
         )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/LabelSelectionDialog.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/LabelSelectionDialog.kt
@@ -28,14 +28,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.model.SelectableLabel
 
 @Composable
 internal fun LabelSelectionDialog(
     onDismissRequest: () -> Unit,
-    searchValue: String,
-    selectableLabels: List<SelectableLabel>,
-    onSearchValueChange: (String) -> Unit,
+    labelFilter: String,
+    filteredLabels: List<LabelUi>,
+    selectedLabels: Set<LabelUi>,
+    onLabelFilterChange: (String) -> Unit,
     onCheckChange: (labelUi: LabelUi) -> Unit,
     onClickLabelSave: () -> Unit,
     modifier: Modifier = Modifier,
@@ -52,13 +52,13 @@ internal fun LabelSelectionDialog(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     TextField(
-                        value = searchValue,
-                        onValueChange = { onSearchValueChange(it) },
+                        value = labelFilter,
+                        onValueChange = { onLabelFilterChange(it) },
                         modifier = Modifier.fillMaxWidth(),
                         label = { Text("검색") },
                         placeholder = { Text("검색 및 추가") },
                         trailingIcon = {
-                            if (searchValue.isNotEmpty()) {
+                            if (labelFilter.isNotEmpty()) {
                                 Icon(
                                     imageVector = Icons.Default.Add,
                                     contentDescription = "Add Label",
@@ -84,13 +84,13 @@ internal fun LabelSelectionDialog(
                         .fillMaxWidth()
                         .verticalScroll(rememberScrollState()),
                 ) {
-                    selectableLabels.forEachIndexed { index, selectableLabel ->
+                    filteredLabels.forEach { filteredLabel ->
                         LabelItem(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(start = 8.dp),
-                            label = selectableLabel.label.name,
-                            isChecked = selectableLabels[index].isSelected,
+                            label = filteredLabel.name,
+                            isChecked = filteredLabel in selectedLabels,
                             onLabelClick = onCheckChange,
                         )
                     }
@@ -104,7 +104,7 @@ internal fun LabelSelectionDialog(
                 ) {
                     TextButton(onClick = {
                         onDismissRequest()
-                        onSearchValueChange("")
+                        onLabelFilterChange("")
                     }) {
                         Text("취소")
                     }
@@ -123,13 +123,17 @@ private fun LabelSelectionDialogPreview() {
     DreamdiaryTheme {
         LabelSelectionDialog(
             onDismissRequest = {},
-            searchValue = "",
-            onSearchValueChange = {},
+            labelFilter = "",
+            onLabelFilterChange = {},
             onCheckChange = {},
-            selectableLabels = listOf(
-                SelectableLabel(LabelUi("악몽"), isSelected = true),
-                SelectableLabel(LabelUi("개꿈"), isSelected = false),
-                SelectableLabel(LabelUi("귀신"), isSelected = false),
+            filteredLabels = listOf(
+                LabelUi("악몽"),
+                LabelUi("개꿈"),
+                LabelUi("귀신"),
+            ),
+            selectedLabels = setOf(
+                LabelUi("악몽"),
+                LabelUi("공룡"),
             ),
             onClickLabelSave = {},
             modifier = Modifier.width(400.dp),

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/LabelSelectionDialog.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/LabelSelectionDialog.kt
@@ -23,10 +23,12 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
 
 @Composable
@@ -55,8 +57,8 @@ internal fun LabelSelectionDialog(
                         value = labelFilter,
                         onValueChange = { onLabelFilterChange(it) },
                         modifier = Modifier.fillMaxWidth(),
-                        label = { Text("검색") },
-                        placeholder = { Text("검색 및 추가") },
+                        label = { Text(stringResource(R.string.label_search)) },
+                        placeholder = { Text(stringResource(R.string.label_search_or_add)) },
                         trailingIcon = {
                             if (labelFilter.isNotEmpty()) {
                                 Icon(

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/model/DiaryWriteUiState.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/model/DiaryWriteUiState.kt
@@ -6,13 +6,9 @@ import java.time.ZonedDateTime
 data class DiaryWriteUiState(
     val title: String = "",
     val content: String = "",
-    val searchValue: String = "",
-    val selectableLabels: List<SelectableLabel> = emptyList(),
+    val labelFilter: String = "",
+    val filteredLabels: List<LabelUi> = emptyList(),
+    val selectedLabels: Set<LabelUi> = mutableSetOf(),
     val sleepEndAt: ZonedDateTime = ZonedDateTime.now(),
     val sleepStartAt: ZonedDateTime = sleepEndAt.minusHours(6),
-)
-
-data class SelectableLabel(
-    val label: LabelUi,
-    val isSelected: Boolean,
 )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/model/DiaryWriteUiState.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/model/DiaryWriteUiState.kt
@@ -8,7 +8,7 @@ data class DiaryWriteUiState(
     val content: String = "",
     val labelFilter: String = "",
     val filteredLabels: List<LabelUi> = emptyList(),
-    val selectedLabels: Set<LabelUi> = mutableSetOf(),
+    val selectedLabels: Set<LabelUi> = emptySet(),
     val sleepEndAt: ZonedDateTime = ZonedDateTime.now(),
     val sleepStartAt: ZonedDateTime = sleepEndAt.minusHours(6),
 )

--- a/feature/diary/src/main/res/values/strings.xml
+++ b/feature/diary/src/main/res/values/strings.xml
@@ -31,4 +31,6 @@
     <string name="home_tab_dream">꿈</string>
     <string name="home_tab_calendar">달력</string>
     <string name="home_diary_write">일기 작성</string>
+    <string name="label_search">검색</string>
+    <string name="label_search_or_add">검색 및 추가</string>
 </resources>


### PR DESCRIPTION
## :man_shrugging: Description

라벨을 검색할 때 라벨이 사라지면 체크 정보도 사라지는 문제점을 해결했습니다.

uiState 가져올 때 구조분해를 사용하지 않게 했습니다. 좀 읽기 어려워서요.
라벨을 검색할 때 사용하는 변수 searchValue와 onSearchValueChange의 이름을 labelFilter, onLabelFilterChange로 이름을 변경했습니다. 기존에는 이름이 애매했던 것 같아요.
selectableLabels로 관리하던 라벨을 filteredLabels와 selectedLabels 두 개로 관리하게 변경했습니다. filteredLabels는 검색어 labelFilter에 의해 필터링 된 라벨이고, selectedLabels는 필터와 상관 없이 선택된 라벨을 보관합니다.
