### PR TITLE
[feat] setting screen을 bottom bar 연결

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
 
     implementation(projects.feature.diary)
     implementation(projects.feature.auth)
+    implementation(projects.feature.setting)
     implementation(projects.core.designsystem)
 
     // Timber

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
@@ -10,6 +10,8 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.diaryHomeScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.navigateToDiaryHomeScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.diaryWriteScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.navigateToDiaryWriteScreen
+import com.boostcamp.dreamteam.dreamdiary.setting.navigateToSettingScreen
+import com.boostcamp.dreamteam.dreamdiary.setting.settingScreen
 import com.boostcamp.dreamteam.dreamdiary.ui.DreamDiaryAppState
 
 @Composable
@@ -45,10 +47,10 @@ fun DreamDiaryNavHost(
                 navController.navigateToDiaryWriteScreen()
             },
             onCommunityClick = {
-//                navController.navigateToCommunityScreen()
+                // TODO: navigate to community screen
             },
             onSettingClick = {
-//                navController.navigateToSettingScreen()
+                navController.navigateToSettingScreen()
             },
             onDiaryItemClick = { diaryUI ->
             },
@@ -56,6 +58,19 @@ fun DreamDiaryNavHost(
 
         diaryWriteScreen(
             onBackClick = navController::navigateUp,
+        )
+
+        settingScreen(
+            onHomeClick = {
+                navController.navigateToDiaryHomeScreen(
+                    navOptions = navOptions {
+                        launchSingleTop = true
+                    },
+                )
+            },
+            onCommunityClick = {
+                // TODO: navigate to community screen
+            }
         )
     }
 }

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
@@ -70,7 +70,7 @@ fun DreamDiaryNavHost(
             },
             onCommunityClick = {
                 // TODO: navigate to community screen
-            }
+            },
         )
     }
 }

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
     implementation(projects.core.domain)
     implementation(projects.core.model)
+    implementation(projects.core.ui)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingNavigation.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingNavigation.kt
@@ -1,0 +1,26 @@
+package com.boostcamp.dreamteam.dreamdiary.setting
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object SettingRoute
+
+fun NavController.navigateToSettingScreen(navOptions: NavOptions? = null) {
+    this.navigate(route = SettingRoute, navOptions)
+}
+
+fun NavGraphBuilder.settingScreen(
+    onHomeClick: () -> Unit,
+    onCommunityClick: () -> Unit,
+) {
+    composable<SettingRoute> {
+        SettingScreen(
+            onNavigateToWriteScreen = onHomeClick,
+            onNavigateToCommunity = onCommunityClick,
+        )
+    }
+}

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingScreen.kt
@@ -52,7 +52,7 @@ internal fun SettingScreen(
         NavigationItem(
             icon = HomeBottomNavItem.MyDream.icon,
             labelRes = HomeBottomNavItem.MyDream.label,
-            isSelected = true,
+            isSelected = false,
             onClick = onNavigateToWriteScreen,
         ),
         NavigationItem(
@@ -64,7 +64,7 @@ internal fun SettingScreen(
         NavigationItem(
             icon = HomeBottomNavItem.Setting.icon,
             labelRes = HomeBottomNavItem.Setting.label,
-            isSelected = false,
+            isSelected = true,
             onClick = {},
         ),
     )

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingScreen.kt
@@ -35,11 +35,40 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.ui.HomeBottomNavItem
+import com.boostcamp.dreamteam.dreamdiary.ui.HomeBottomNavigation
+import com.boostcamp.dreamteam.dreamdiary.ui.NavigationItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun SettingScreen(modifier: Modifier = Modifier) {
+internal fun SettingScreen(
+    modifier: Modifier = Modifier,
+    onNavigateToWriteScreen: () -> Unit,
+    onNavigateToCommunity: () -> Unit,
+) {
     val rememberScrollState = rememberScrollState()
+
+    val navigationItems = listOf(
+        NavigationItem(
+            icon = HomeBottomNavItem.MyDream.icon,
+            labelRes = HomeBottomNavItem.MyDream.label,
+            isSelected = true,
+            onClick = onNavigateToWriteScreen,
+        ),
+        NavigationItem(
+            icon = HomeBottomNavItem.Community.icon,
+            labelRes = HomeBottomNavItem.Community.label,
+            isSelected = false,
+            onClick = onNavigateToCommunity,
+        ),
+        NavigationItem(
+            icon = HomeBottomNavItem.Setting.icon,
+            labelRes = HomeBottomNavItem.Setting.label,
+            isSelected = false,
+            onClick = {},
+        ),
+    )
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -48,6 +77,9 @@ internal fun SettingScreen(modifier: Modifier = Modifier) {
                     Text(text = stringResource(R.string.setting_title))
                 },
             )
+        },
+        bottomBar = {
+            HomeBottomNavigation(items = navigationItems)
         },
     ) { innerPadding ->
         Column(
@@ -162,6 +194,9 @@ private fun SettingOption(
 @Composable
 private fun SettingScreenPreview() {
     DreamdiaryTheme {
-        SettingScreen()
+        SettingScreen(
+            onNavigateToWriteScreen = {},
+            onNavigateToCommunity = {},
+        )
     }
 }

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingScreen.kt
@@ -42,9 +42,9 @@ import com.boostcamp.dreamteam.dreamdiary.ui.NavigationItem
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SettingScreen(
-    modifier: Modifier = Modifier,
     onNavigateToWriteScreen: () -> Unit,
     onNavigateToCommunity: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val rememberScrollState = rememberScrollState()
 


### PR DESCRIPTION
## :man_shrugging: Description
setting screen bottom bar와 연결했습니다.

이 부분의 코드가 중복되는데 어떻게 해결하는 것이 좋을까요?

```kt
val navigationItems = listOf(
        NavigationItem(
            icon = HomeBottomNavItem.MyDream.icon,
            labelRes = HomeBottomNavItem.MyDream.label,
            isSelected = true,
            onClick = {  },
        ),
        NavigationItem(
            icon = HomeBottomNavItem.Community.icon,
            labelRes = HomeBottomNavItem.Community.label,
            isSelected = false,
            onClick = onNavigateToCommunity,
        ),
        NavigationItem(
            icon = HomeBottomNavItem.Setting.icon,
            labelRes = HomeBottomNavItem.Setting.label,
            isSelected = false,
            onClick = onNavigateToSetting,
        ),
    )
```

## :camera: Screenshots

![image](https://github.com/user-attachments/assets/d42d0dac-b111-47a1-9be0-1134e2d1e68d)
