### PR TITLE
[feat] 꿈일기 상세 화면

### DIFF
--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
@@ -6,6 +6,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.boostcamp.dreamteam.dreamdiary.feature.auth.SignInRoute
 import com.boostcamp.dreamteam.dreamdiary.feature.auth.signInScreen
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.DiaryDetailRoute
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.diaryDetailScreen
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.navigateToDiaryDetailScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.diaryHomeScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.navigateToDiaryHomeScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.diaryWriteScreen

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
@@ -6,6 +6,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.boostcamp.dreamteam.dreamdiary.feature.auth.SignInRoute
 import com.boostcamp.dreamteam.dreamdiary.feature.auth.signInScreen
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.DiaryDetailNavigation
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.diaryDetailScreen
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.navigateToDiaryDetailScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.diaryHomeScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.navigateToDiaryHomeScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.diaryWriteScreen
@@ -51,10 +54,20 @@ fun DreamDiaryNavHost(
 //                navController.navigateToSettingScreen()
             },
             onDiaryItemClick = { diaryUI ->
+                navController.navigateToDiaryDetailScreen(
+                    route = DiaryDetailNavigation(diaryUI.id),
+                    navOptions = navOptions {
+                        launchSingleTop = true
+                    },
+                )
             },
         )
 
         diaryWriteScreen(
+            onBackClick = navController::navigateUp,
+        )
+
+        diaryDetailScreen(
             onBackClick = navController::navigateUp,
         )
     }

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/navigation/DreamDiaryNavHost.kt
@@ -6,7 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.boostcamp.dreamteam.dreamdiary.feature.auth.SignInRoute
 import com.boostcamp.dreamteam.dreamdiary.feature.auth.signInScreen
-import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.DiaryDetailNavigation
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.DiaryDetailRoute
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.diaryDetailScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.navigateToDiaryDetailScreen
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.home.diaryHomeScreen
@@ -55,7 +55,7 @@ fun DreamDiaryNavHost(
             },
             onDiaryItemClick = { diaryUI ->
                 navController.navigateToDiaryDetailScreen(
-                    route = DiaryDetailNavigation(diaryUI.id),
+                    route = DiaryDetailRoute(diaryUI.id),
                     navOptions = navOptions {
                         launchSingleTop = true
                     },

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryLabelEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryWithLabels
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
 import kotlinx.coroutines.flow.Flow
 import java.time.Instant
@@ -70,4 +71,8 @@ interface DreamDiaryDao {
         start: Instant,
         end: Instant,
     ): Flow<List<DreamDiaryEntity>>
+
+    @Transaction
+    @Query("select * from diary where id = :id")
+    suspend fun getDreamDiary(id: String): DreamDiaryWithLabels
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/DreamDiaryWithLabels.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/DreamDiaryWithLabels.kt
@@ -1,0 +1,19 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.database.model
+
+import androidx.room.Embedded
+import androidx.room.Junction
+import androidx.room.Relation
+
+data class DreamDiaryWithLabels(
+    @Embedded val dreamDiary: DreamDiaryEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "label",
+        associateBy = Junction(
+            value = DreamDiaryLabelEntity::class,
+            parentColumn = "diaryId",
+            entityColumn = "labelId",
+        )
+    )
+    val labels: List<LabelEntity>
+)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/DreamDiaryWithLabels.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/DreamDiaryWithLabels.kt
@@ -13,7 +13,7 @@ data class DreamDiaryWithLabels(
             value = DreamDiaryLabelEntity::class,
             parentColumn = "diaryId",
             entityColumn = "labelId",
-        )
+        ),
     )
-    val labels: List<LabelEntity>
+    val labels: List<LabelEntity>,
 )

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/DefaultDreamDiaryRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/DefaultDreamDiaryRepository.kt
@@ -73,4 +73,8 @@ internal class DefaultDreamDiaryRepository @Inject constructor(
         dreamDiaryDao
             .getDreamDiariesBySleepEndInRange(start, end)
             .map { list -> list.map { it.toDomain() } }
+
+    override suspend fun getDreamDiary(id: String): Diary {
+        return dreamDiaryDao.getDreamDiary(id).toDomain()
+    }
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/DreamDiaryRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/DreamDiaryRepository.kt
@@ -30,4 +30,6 @@ interface DreamDiaryRepository {
         start: Instant,
         end: Instant,
     ): Flow<List<Diary>>
+
+    suspend fun getDreamDiary(id: String): Diary
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/Mapper.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/Mapper.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.dreamteam.dreamdiary.core.data.repository
 
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryWithLabels
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.model.Diary
 import com.boostcamp.dreamteam.dreamdiary.core.model.Label
@@ -22,5 +23,19 @@ fun DreamDiaryEntity.toDomain(): Diary {
 fun LabelEntity.toDomain(): Label {
     return Label(
         name = this.label,
+    )
+}
+
+fun DreamDiaryWithLabels.toDomain(): Diary {
+    return Diary(
+        id = dreamDiary.id,
+        title = dreamDiary.title,
+        content = dreamDiary.body,
+        createdAt = dreamDiary.createdAt,
+        updatedAt = dreamDiary.updatedAt,
+        images = listOf(),
+        labels = this.labels.map { it.toDomain() },
+        sleepStartAt = dreamDiary.sleepStartAt,
+        sleepEndAt = dreamDiary.sleepEndAt,
     )
 }

--- a/core/domain/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/domain/usecase/GetDreamDiaryUseCase.kt
+++ b/core/domain/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/domain/usecase/GetDreamDiaryUseCase.kt
@@ -1,0 +1,13 @@
+package com.boostcamp.dreamteam.dreamdiary.core.domain.usecase
+
+import com.boostcamp.dreamteam.dreamdiary.core.data.repository.DreamDiaryRepository
+import com.boostcamp.dreamteam.dreamdiary.core.model.Diary
+import javax.inject.Inject
+
+class GetDreamDiaryUseCase @Inject constructor(
+    private val dreamDiaryRepository: DreamDiaryRepository
+) {
+    suspend operator fun invoke(id: String): Diary {
+        return dreamDiaryRepository.getDreamDiary(id)
+    }
+}

--- a/core/domain/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/domain/usecase/GetDreamDiaryUseCase.kt
+++ b/core/domain/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/domain/usecase/GetDreamDiaryUseCase.kt
@@ -5,7 +5,7 @@ import com.boostcamp.dreamteam.dreamdiary.core.model.Diary
 import javax.inject.Inject
 
 class GetDreamDiaryUseCase @Inject constructor(
-    private val dreamDiaryRepository: DreamDiaryRepository
+    private val dreamDiaryRepository: DreamDiaryRepository,
 ) {
     suspend operator fun invoke(id: String): Diary {
         return dreamDiaryRepository.getDreamDiary(id)

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailNavigation.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailNavigation.kt
@@ -1,0 +1,27 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.detail
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DiaryDetailNavigation(
+    val id: String,
+)
+
+fun NavHostController.navigateToDiaryDetailScreen(
+    route: DiaryDetailNavigation,
+    navOptions: NavOptions,
+) {
+    navigate(route, navOptions)
+}
+
+fun NavGraphBuilder.diaryDetailScreen(onBackClick: () -> Unit) {
+    composable<DiaryDetailNavigation> {
+        DiaryDetailScreen(
+            onBackClick = onBackClick,
+        )
+    }
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailNavigation.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailNavigation.kt
@@ -7,19 +7,19 @@ import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class DiaryDetailNavigation(
+data class DiaryDetailRoute(
     val id: String,
 )
 
 fun NavHostController.navigateToDiaryDetailScreen(
-    route: DiaryDetailNavigation,
+    route: DiaryDetailRoute,
     navOptions: NavOptions,
 ) {
     navigate(route, navOptions)
 }
 
 fun NavGraphBuilder.diaryDetailScreen(onBackClick: () -> Unit) {
-    composable<DiaryDetailNavigation> {
+    composable<DiaryDetailRoute> {
         DiaryDetailScreen(
             onBackClick = onBackClick,
         )

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailScreen.kt
@@ -1,0 +1,144 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.detail
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.filteredLabelsPreview
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.component.DiaryWriteScreenHeader
+import java.time.ZonedDateTime
+
+@Composable
+fun DiaryDetailScreen(
+    onBackClick: () -> Unit,
+    viewModel: DiaryDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val diaryUiState = uiState.diaryUIState
+    val loading = uiState.loading
+    if (!loading) {
+        DiaryDetailScreen(
+            title = diaryUiState.title,
+            content = diaryUiState.content,
+            sleepStartAt = diaryUiState.sleepStartAt,
+            sleepEndAt = diaryUiState.sleepEndAt,
+            labels = diaryUiState.labels,
+            onBackClick = onBackClick,
+        )
+    }
+}
+
+@Composable
+internal fun DiaryDetailScreen(
+    title: String,
+    content: String,
+    sleepStartAt: ZonedDateTime,
+    sleepEndAt: ZonedDateTime,
+    labels: List<LabelUi>,
+    onBackClick: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            DiaryDetailScreenTopAppBar(
+                onBackClick = onBackClick,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+            )
+
+            DiaryWriteScreenHeader(
+                labelFilter = "",
+                onLabelFilterChange = { },
+                filteredLabels = emptyList(),
+                selectedLabels = labels.toSet(),
+                sleepStartAt = sleepStartAt,
+                sleepEndAt = sleepEndAt,
+                onSleepStartAtChange = { },
+                onSleepEndAtChange = { },
+                onCheckChange = { },
+                onClickLabelSave = { },
+                modifier = Modifier.padding(vertical = 16.dp),
+                readOnly = true,
+            )
+
+            DiaryDetailContent(
+                content = content,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DiaryDetailScreenTopAppBar(onBackClick: () -> Unit) {
+    TopAppBar(
+        navigationIcon = {
+            IconButton(
+                onClick = onBackClick,
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                    contentDescription = "",
+                )
+            }
+        },
+        title = { },
+    )
+}
+
+@Composable
+internal fun DiaryDetailContent(
+    content: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(vertical = 16.dp),
+    ) {
+        Text(
+            text = content,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DiaryHomeScreenContentPreview() {
+    DreamdiaryTheme {
+        DiaryDetailScreen(
+            title = "투명 드래곤 크앙!",
+            content = "Body text for whatever you’d like to say. Add main takeaway points, quotes, anecdotes, or even a very very short story.",
+            sleepStartAt = ZonedDateTime.now(),
+            sleepEndAt = ZonedDateTime.now(),
+            labels = filteredLabelsPreview,
+            onBackClick = {},
+        )
+    }
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -15,11 +16,13 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.filteredLabelsPreview
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.write.component.DiaryWriteScreenHeader
@@ -104,7 +107,17 @@ internal fun DiaryDetailScreenTopAppBar(onBackClick: () -> Unit) {
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                    contentDescription = "",
+                    contentDescription = stringResource(R.string.detail_back),
+                )
+            }
+        },
+        actions = {
+            IconButton(
+                onClick = { /*TODO*/ },
+            ) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(R.string.detail_menu),
                 )
             }
         },

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailViewModel.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailViewModel.kt
@@ -1,0 +1,39 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.detail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.dreamteam.dreamdiary.core.domain.usecase.GetDreamDiaryUseCase
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.model.DiaryDetailUiState
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.model.toUIState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DiaryDetailViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getDreamDiaryUseCase: GetDreamDiaryUseCase,
+) : ViewModel() {
+    private val id: String? = savedStateHandle.get<String>("id")
+
+    private val _uiState = MutableStateFlow(DiaryDetailUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            if (id != null) {
+                val dreamDiary = getDreamDiaryUseCase.invoke(id)
+                _uiState.update {
+                    it.copy(
+                        diaryUIState = dreamDiary.toUIState(),
+                        loading = false,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/model/DiaryDetailUiState.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/model/DiaryDetailUiState.kt
@@ -1,0 +1,32 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.detail.model
+
+import com.boostcamp.dreamteam.dreamdiary.core.model.Diary
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.toLabelUi
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+data class DiaryDetailUiState(
+    val diaryUIState: DiaryUiState = DiaryUiState(),
+    val loading: Boolean = true,
+)
+
+data class DiaryUiState(
+    val id: String = "",
+    val title: String = "",
+    val content: String = "",
+    val labels: List<LabelUi> = listOf(),
+    val sleepStartAt: ZonedDateTime = ZonedDateTime.now(),
+    val sleepEndAt: ZonedDateTime = ZonedDateTime.now(),
+)
+
+fun Diary.toUIState(): DiaryUiState {
+    return DiaryUiState(
+        id = this.id,
+        title = this.title,
+        labels = this.labels.map { it.toLabelUi() },
+        content = this.content,
+        sleepStartAt = this.sleepStartAt.atZone(ZoneId.systemDefault()),
+        sleepEndAt = this.sleepEndAt.atZone(ZoneId.systemDefault()),
+    )
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -127,7 +127,7 @@ private fun DiaryHomeScreenContent(
     onSearchClick: () -> Unit = {},
     onNotificationClick: () -> Unit = {},
 ) {
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
     val tabs = listOf(stringResource(R.string.home_tab_dream), stringResource(R.string.home_tab_calendar))
 
     Column(

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/DiaryWriteScreenHeader.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/DiaryWriteScreenHeader.kt
@@ -66,7 +66,7 @@ internal fun DiaryWriteScreenHeader(
     modifier: Modifier = Modifier,
     readOnly: Boolean = false,
 ) {
-    var isLabelSelectionDialogOpen by remember { mutableStateOf(false) }
+    var isLabelSelectionDialogOpen by rememberSaveable { mutableStateOf(false) }
 
     Column(modifier = modifier) {
         WriteDateInfo(

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/DiaryWriteScreenHeader.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/component/DiaryWriteScreenHeader.kt
@@ -62,6 +62,7 @@ internal fun DiaryWriteScreenHeader(
     onCheckChange: (labelUi: LabelUi) -> Unit,
     onClickLabelSave: () -> Unit,
     modifier: Modifier = Modifier,
+    readOnly: Boolean = false,
 ) {
     var isLabelSelectionDialogOpen by remember { mutableStateOf(false) }
 
@@ -73,13 +74,14 @@ internal fun DiaryWriteScreenHeader(
                 onSleepStartAtChange(sleepStartAt)
                 onSleepEndAtChange(sleepEndAt)
             },
+            readOnly = readOnly,
         )
 
         Spacer(modifier = Modifier.height(8.dp))
 
         Row(
             modifier = Modifier
-                .clickable {
+                .clickable(enabled = !readOnly) {
                     isLabelSelectionDialogOpen = true
                 },
             verticalAlignment = Alignment.CenterVertically,
@@ -118,6 +120,7 @@ internal fun WriteDateInfo(
     sleepStartAt: ZonedDateTime,
     sleepEndAt: ZonedDateTime,
     onTimeChange: (ZonedDateTime, ZonedDateTime) -> Unit,
+    readOnly: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val truncatedSleepStart = sleepStartAt.truncatedTo(ChronoUnit.MINUTES)
@@ -136,6 +139,7 @@ internal fun WriteDateInfo(
                 val newSleepEnd = newSleepStart.plusHours(diffHour)
                 onTimeChange(newSleepStart, newSleepEnd)
             },
+            readOnly = readOnly,
         )
 
         TimeHeader(
@@ -149,6 +153,7 @@ internal fun WriteDateInfo(
                 }
                 onTimeChange(newSleepStart, newSleepEnd)
             },
+            readOnly = readOnly,
         )
     }
 }
@@ -159,6 +164,7 @@ private fun TimeHeader(
     startTime: LocalTime,
     endTime: LocalTime,
     onConfirmStartTime: (LocalTime, LocalTime) -> Unit,
+    readOnly: Boolean,
     modifier: Modifier = Modifier,
 ) {
     var isTimePickerOpen by rememberSaveable { mutableStateOf(false) }
@@ -207,7 +213,7 @@ private fun TimeHeader(
         Icon(Icons.Outlined.Timer, contentDescription = stringResource(R.string.write_select_time))
 
         Text(
-            modifier = Modifier.clickable {
+            modifier = Modifier.clickable(enabled = !readOnly) {
                 tabIndex = 0
                 isTimePickerOpen = true
             },
@@ -215,7 +221,7 @@ private fun TimeHeader(
         )
         Text(text = "~")
         Text(
-            modifier = Modifier.clickable {
+            modifier = Modifier.clickable(enabled = !readOnly) {
                 tabIndex = 1
                 isTimePickerOpen = true
             },
@@ -230,6 +236,7 @@ private fun DateHeader(
     date: LocalDate,
     onConfirm: (Long) -> Unit,
     modifier: Modifier = Modifier,
+    readOnly: Boolean,
     locale: Locale = Locale.getDefault(),
 ) {
     var isDatePickerOpen by rememberSaveable { mutableStateOf(false) }
@@ -245,7 +252,7 @@ private fun DateHeader(
     }
 
     Row(
-        modifier = modifier.clickable {
+        modifier = modifier.clickable(enabled = !readOnly) {
             isDatePickerOpen = true
         },
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/diary/src/main/res/values/strings.xml
+++ b/feature/diary/src/main/res/values/strings.xml
@@ -33,4 +33,6 @@
     <string name="home_diary_write">일기 작성</string>
     <string name="label_search">검색</string>
     <string name="label_search_or_add">검색 및 추가</string>
+    <string name="detail_back">뒤로가기</string>
+    <string name="detail_menu">메뉴</string>
 </resources>


### PR DESCRIPTION
#17 

## :man_shrugging: Description

꿈일기 상세 화면을 구현했습니다.
- 리스트에서 네비게이션
- 꿈일기와 관련 라벨을 한꺼번에 가져올 수 있는 유즈케이스 및 dao 함수

꿈일기 홈 화면에서 탭 인덱스를 savable에 보관하도록 변경했습니다. 상세 화면 갔다가 돌아왔을 때 유지가 되면 좋을 것 같아서요.

## :camera: Screenshots

![image](https://github.com/user-attachments/assets/26ebb361-4d56-43cd-8aea-4b87ed36b478)

