### PR TITLE
[refactor] DiaryMenuButton 컴포넌트 분리

### DIFF
--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/component/DiaryMenuButton.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/component/DiaryMenuButton.kt
@@ -1,0 +1,75 @@
+package com.boostcamp.dreamteam.dreamdiary.feature.diary.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
+
+@Composable
+internal fun DiaryMenuButton(
+    isVisible: Boolean,
+    onVisibleChange: (Boolean) -> Unit,
+    onDeleteDiary: () -> Unit,
+    onDiaryEdit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        IconButton(
+            onClick = { onVisibleChange(true) },
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(R.string.home_list_card_menu),
+                modifier = Modifier.height(16.dp),
+            )
+        }
+        DropdownMenu(
+            expanded = isVisible,
+            onDismissRequest = { onVisibleChange(false) },
+        ) {
+            DropdownMenuItem(
+                text = { Text(text = stringResource(R.string.home_list_card_menu_edit)) },
+                onClick = {
+                    onDiaryEdit()
+                    onVisibleChange(false)
+                },
+                leadingIcon = { Icon(imageVector = Icons.Outlined.Edit, contentDescription = null) },
+            )
+            DropdownMenuItem(
+                text = { Text(text = stringResource(R.string.home_list_card_menu_delete)) },
+                onClick = {
+                    onDeleteDiary()
+                    onVisibleChange(false)
+                },
+                leadingIcon = { Icon(imageVector = Icons.Outlined.Delete, contentDescription = null) },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DiaryEditDropDownMenuPreview() {
+    DreamdiaryTheme {
+        DiaryMenuButton(
+            isVisible = true,
+            onVisibleChange = { },
+            onDeleteDiary = { },
+            onDiaryEdit = { },
+        )
+    }
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCard.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCard.kt
@@ -13,13 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.CalendarToday
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -39,6 +33,7 @@ import com.boostcamp.dreamteam.dreamdiary.designsystem.component.DdAsyncImage
 import com.boostcamp.dreamteam.dreamdiary.designsystem.component.DdCard
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
+import com.boostcamp.dreamteam.dreamdiary.feature.diary.component.DiaryMenuButton
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diaryPreview1
 import java.time.chrono.Chronology
@@ -134,34 +129,12 @@ private fun CardHeadline(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
-        IconButton(onClick = { isMenuVisible = true }) {
-            Icon(
-                imageVector = Icons.Default.MoreVert,
-                contentDescription = stringResource(R.string.home_list_card_menu),
-                modifier = Modifier.height(16.dp),
-            )
-            DropdownMenu(
-                expanded = isMenuVisible,
-                onDismissRequest = { isMenuVisible = false },
-            ) {
-                DropdownMenuItem(
-                    text = { Text(text = stringResource(R.string.home_list_card_menu_edit)) },
-                    onClick = {
-                        onDiaryEdit(diary)
-                        isMenuVisible = false
-                    },
-                    leadingIcon = { Icon(imageVector = Icons.Outlined.Edit, contentDescription = null) },
-                )
-                DropdownMenuItem(
-                    text = { Text(text = stringResource(R.string.home_list_card_menu_delete)) },
-                    onClick = {
-                        onDeleteDiary(diary)
-                        isMenuVisible = false
-                    },
-                    leadingIcon = { Icon(imageVector = Icons.Outlined.Delete, contentDescription = null) },
-                )
-            }
-        }
+        DiaryMenuButton(
+            isVisible = isMenuVisible,
+            onVisibleChange = { isMenuVisible = it },
+            onDeleteDiary = { onDeleteDiary(diary) },
+            onDiaryEdit = { onDiaryEdit(diary) },
+        )
     }
 }
 


### PR DESCRIPTION
## :man_shrugging: Description

-[x] 상세 화면에서도 사용하기 위해 `DiaryMenuButton` component 분리