### PR TITLE
[fix] 작성 화면에서 스크롤 시 padding이 이상하게 적용되는 문제 해결

### DIFF
--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
@@ -112,7 +112,9 @@ fun DiaryWriteScreen(
         onClickLabelSave = viewModel::addLabel,
         onContentTextChange = viewModel::setContentText,
         onContentImageDelete = viewModel::deleteContentImage,
-        modifier = Modifier.imePadding(),
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding(),
     )
 }
 


### PR DESCRIPTION
## :man_shrugging: Description

- [x] 아래의 스크린샷처럼 발생하는 문제 해결

## :camera: Screenshots

<img width="30%" src="https://github.com/user-attachments/assets/9002bdd4-7e01-4725-b59f-d86b566b7d58">
