### PR TITLE
[chore] configuration-cache를 사용하도록 설정

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,4 @@ android.nonTransitiveRClass=true
 org.gradle.parallel=true
 # Enable caching between builds.
 org.gradle.caching=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
<!-- ex) close #10, resolves #123 -->

## :man_shrugging: Description

`2.1`초나 걸리는 configuration 과정을 cache를 사용하면 건너뛸 수 있다고 합니다.

### 3줄요약

1. build는 3단계로 구성되어있음 (1. Initialization 2. Configuration 3. Execution)
2. Configuration과정이란 모든 build.gradle(.kts)와 properties를 모아 task 그래프를 그리며  빌드를 준비하는 과정
3. 캐시가 있으면 configuration 과정을 스킵함

## :camera: Screenshots

![image](https://github.com/user-attachments/assets/3b135ad1-18bd-4a26-b3b8-e5f96013c4cc)

## 📝 관련자료

https://docs.gradle.org/current/userguide/build_lifecycle.html#sec:configuration
https://docs.gradle.org/current/userguide/configuration_cache.html

