### PR TITLE
[feat] 커뮤니티 일기 카드 구현

### DIFF
--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/CommunityNavigation.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/CommunityNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navOptions
 import androidx.navigation.navigation
 import com.boostcamp.dreamteam.dreamdiary.community.list.CommunityListScreen
 import kotlinx.serialization.Serializable
@@ -36,7 +37,12 @@ fun NavGraphBuilder.communityGraph(
             CommunityListScreen(
                 onNavigateToDiary = onDiaryClick,
                 onNavigateToSetting = onSettingClick,
-                onDiaryClick = { diaryId -> navController.navigateToCommunityDetail(diaryId) },
+                onDiaryClick = { diaryId ->
+                    navController.navigateToCommunityDetail(
+                        diaryId = diaryId,
+                        navOptions = navOptions { launchSingleTop = true },
+                    )
+                },
             )
         }
         composable<CommunityGraph.CommunityDetailRoute> { backStackEntry ->
@@ -47,11 +53,11 @@ fun NavGraphBuilder.communityGraph(
 }
 
 private fun NavController.navigateToCommunityDetail(
-    id: String,
+    diaryId: String,
     navOptions: NavOptions? = null,
 ) {
     navigate(
-        route = CommunityGraph.CommunityDetailRoute(id),
+        route = CommunityGraph.CommunityDetailRoute(diaryId),
         navOptions = navOptions,
     )
 }

--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/list/CommunityListScreen.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/list/CommunityListScreen.kt
@@ -1,5 +1,8 @@
 package com.boostcamp.dreamteam.dreamdiary.community.list
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -8,15 +11,18 @@ import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.dreamteam.dreamdiary.community.R
+import com.boostcamp.dreamteam.dreamdiary.community.list.component.CommunityDiaryCard
 import com.boostcamp.dreamteam.dreamdiary.community.model.DiaryUi
 import com.boostcamp.dreamteam.dreamdiary.community.model.diariesUiPreview
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
@@ -63,11 +69,14 @@ private fun CommunityListScreenContent(
         ),
     )
 
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             CenterAlignedTopAppBar(
                 title = { Text(text = stringResource(R.string.community_title)) },
+                scrollBehavior = scrollBehavior,
             )
         },
         bottomBar = {
@@ -77,11 +86,19 @@ private fun CommunityListScreenContent(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 16.dp),
+                .padding(innerPadding),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            items(items = diaries, key = { it.id }) { diary: DiaryUi ->
-                // TODO: Implement DiaryCard
+            items(items = diaries, key = { it.id }) { diary ->
+                CommunityDiaryCard(
+                    diary = diary,
+                    onClickMenu = { /* TODO: 메뉴 눌렀을 때 기능 추가하기 */ },
+                    onClickLike = { /* TODO: 좋아요 눌렀을 때 기능 추가하기 */ },
+                    modifier = Modifier
+                        .clickable(onClick = { onDiaryClick(diary) })
+                        .animateItem(),
+                )
             }
         }
     }

--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/list/component/CommunityDiaryCard.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/list/component/CommunityDiaryCard.kt
@@ -1,0 +1,213 @@
+package com.boostcamp.dreamteam.dreamdiary.community.list.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.dreamteam.dreamdiary.community.R
+import com.boostcamp.dreamteam.dreamdiary.community.model.DiaryUi
+import com.boostcamp.dreamteam.dreamdiary.community.model.UserUi
+import com.boostcamp.dreamteam.dreamdiary.community.model.diaryUiPreview1
+import com.boostcamp.dreamteam.dreamdiary.community.model.diaryUiPreview2
+import com.boostcamp.dreamteam.dreamdiary.designsystem.component.DdAsyncImage
+import com.boostcamp.dreamteam.dreamdiary.designsystem.component.DdCard
+
+@Composable
+internal fun CommunityDiaryCard(
+    diary: DiaryUi,
+    onClickMenu: (diary: DiaryUi) -> Unit,
+    onClickLike: (diary: DiaryUi) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    DdCard(
+        headline = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = diary.title,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        modifier = modifier,
+        overline = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                AuthorHeader(
+                    author = diary.author,
+                    onMenuClick = { onClickMenu(diary) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                diary.thumbnail?.let { thumbnail ->
+                    DdAsyncImage(
+                        model = thumbnail,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(16 / 9f),
+                    )
+                }
+            }
+        },
+        underline = {
+            Row(verticalAlignment = Alignment.Bottom) {
+                Icon(
+                    imageVector = Icons.Default.CalendarToday,
+                    contentDescription = stringResource(id = R.string.community_list_card_create_date),
+                    modifier = Modifier
+                        .height(16.dp)
+                        .padding(2.dp),
+                )
+                Spacer(modifier = Modifier.width(2.dp))
+                Text(text = diary.sharedAt.formattedDate)
+
+                Spacer(modifier = Modifier.width(4.dp))
+
+                Icon(
+                    imageVector = Icons.Default.AccessTime,
+                    contentDescription = stringResource(id = R.string.community_list_card_create_at),
+                    modifier = Modifier
+                        .height(16.dp)
+                        .padding(2.dp),
+                )
+                Spacer(modifier = Modifier.width(2.dp))
+
+                Text(text = diary.sharedAt.formattedTime)
+            }
+        },
+        tail = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.Comment,
+                    contentDescription = stringResource(R.string.community_list_diary_card_comment),
+                )
+                Spacer(Modifier.width(4.dp))
+                ProvideTextStyle(
+                    value = MaterialTheme.typography.bodyMedium,
+                ) {
+                    Text(text = diary.commentCount.toString())
+                }
+                IconButton(
+                    onClick = { onClickLike(diary) },
+                ) {
+                    Icon(
+                        imageVector = if (diary.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                        contentDescription = stringResource(R.string.community_list_diary_card_like),
+                        tint = if (diary.isLiked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+        },
+    ) {
+        Text(
+            text = diary.previewText,
+            modifier = Modifier,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun AuthorHeader(
+    author: UserUi,
+    onMenuClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        DdAsyncImage(
+            model = author.profileImageUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .size(40.dp)
+                .clip(MaterialTheme.shapes.extraLarge)
+                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)),
+            contentScale = ContentScale.Crop,
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.SpaceBetween) {
+            Text(
+                text = author.username,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = "3분전",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                ),
+            )
+        }
+        IconButton(
+            onClick = onMenuClick,
+        ) {
+            Icon(imageVector = Icons.Outlined.MoreVert, contentDescription = null)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CommunityDiaryCardPreviewWithoutImage() {
+    MaterialTheme {
+        CommunityDiaryCard(
+            diary = diaryUiPreview1,
+            onClickMenu = { },
+            onClickLike = { },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CommunityDiaryCardPreviewWithImage() {
+    MaterialTheme {
+        CommunityDiaryCard(
+            diary = diaryUiPreview2,
+            onClickMenu = { },
+            onClickLike = { },
+        )
+    }
+}

--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/model/DiaryUi.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/model/DiaryUi.kt
@@ -1,19 +1,50 @@
 package com.boostcamp.dreamteam.dreamdiary.community.model
 
+import com.boostcamp.dreamteam.dreamdiary.community.model.vo.DisplayableDateTime
+import com.boostcamp.dreamteam.dreamdiary.community.model.vo.toDisplayableDateTime
+import java.time.Instant
+import java.time.ZoneId
+
 data class DiaryUi(
     val id: String,
+    val thumbnail: String? = null,
+    val title: String,
+    val previewText: String,
+    val sharedAt: DisplayableDateTime,
+    val commentCount: Long,
+    val isLiked: Boolean,
+    val author: UserUi,
 )
 
 internal val diaryUiPreview1 = DiaryUi(
     id = "1",
+    title = "Diary 1",
+    previewText = "This is a preview text for Diary 1",
+    sharedAt = Instant.now().toDisplayableDateTime(zoneId = ZoneId.systemDefault()),
+    commentCount = 10,
+    isLiked = false,
+    author = userUiPreview1,
 )
 
-private val diaryUiPreview2 = DiaryUi(
+internal val diaryUiPreview2 = DiaryUi(
     id = "2",
+    thumbnail = "https://picsum.photos/200/300",
+    title = "Diary 2",
+    previewText = "This is a preview text for Diary 2",
+    sharedAt = Instant.now().toDisplayableDateTime(zoneId = ZoneId.systemDefault()),
+    commentCount = 2147483647,
+    isLiked = true,
+    author = userUiPreview2,
 )
 
 private val diaryUiPreview3 = DiaryUi(
     id = "3",
+    title = "Diary 3",
+    previewText = "This is a preview text for Diary 3",
+    sharedAt = Instant.now().toDisplayableDateTime(zoneId = ZoneId.systemDefault()),
+    commentCount = 0,
+    isLiked = false,
+    author = userUiPreview3,
 )
 
 internal val diariesUiPreview = listOf(

--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/model/UserUi.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/model/UserUi.kt
@@ -1,0 +1,31 @@
+package com.boostcamp.dreamteam.dreamdiary.community.model
+
+data class UserUi(
+    val id: String,
+    val username: String,
+    val profileImageUrl: String,
+)
+
+internal val userUiPreview1 = UserUi(
+    id = "1",
+    username = "User 1",
+    profileImageUrl = "https://picsum.photos/200/300",
+)
+
+internal val userUiPreview2 = UserUi(
+    id = "2",
+    username = "User 2",
+    profileImageUrl = "https://picsum.photos/200/300",
+)
+
+internal val userUiPreview3 = UserUi(
+    id = "3",
+    username = "User 3",
+    profileImageUrl = "https://picsum.photos/200/300",
+)
+
+internal val usersUiPreview = listOf(
+    userUiPreview1,
+    userUiPreview2,
+    userUiPreview3,
+)

--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/model/vo/DisplayableDateTime.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/model/vo/DisplayableDateTime.kt
@@ -1,0 +1,34 @@
+package com.boostcamp.dreamteam.dreamdiary.community.model.vo
+
+import java.time.Instant
+import java.time.ZoneId
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+data class DisplayableDateTime(
+    val value: Instant,
+    val formattedDate: String,
+    val formattedTime: String,
+) {
+    companion object {
+        val localedFormatter: Map<Locale, DisplayableDateTimeFormatter> = ConcurrentHashMap()
+    }
+}
+
+internal fun Instant.toDisplayableDateTime(
+    zoneId: ZoneId = ZoneId.systemDefault(),
+    locale: Locale = Locale.getDefault(),
+): DisplayableDateTime {
+    val zonedDateTime = this.atZone(zoneId)
+    val formatters = DisplayableDateTime.localedFormatter.getOrPut(locale)
+
+    return DisplayableDateTime(
+        value = this,
+        formattedDate = zonedDateTime.format(formatters.dateFormatter),
+        formattedTime = zonedDateTime.format(formatters.timeFormatter),
+    )
+}
+
+private fun Map<Locale, DisplayableDateTimeFormatter>.getOrPut(locale: Locale): DisplayableDateTimeFormatter =
+    this[locale]
+        ?: DisplayableDateTimeFormatter.of(locale = locale).also { this.toMutableMap()[locale] = it }

--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/model/vo/DisplayableDateTimeFormatter.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/model/vo/DisplayableDateTimeFormatter.kt
@@ -1,0 +1,35 @@
+package com.boostcamp.dreamteam.dreamdiary.community.model.vo
+
+import java.time.chrono.Chronology
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.FormatStyle
+import java.util.Locale
+
+data class DisplayableDateTimeFormatter(
+    val dateFormatter: DateTimeFormatter,
+    val timeFormatter: DateTimeFormatter,
+) {
+    companion object {
+        fun of(locale: Locale): DisplayableDateTimeFormatter {
+            val dateFormatter = DateTimeFormatter.ofPattern(
+                DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+                    FormatStyle.FULL,
+                    null,
+                    Chronology.ofLocale(locale),
+                    locale,
+                ),
+            )
+            val timeFormatter = DateTimeFormatter.ofPattern(
+                DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+                    null,
+                    FormatStyle.SHORT,
+                    Chronology.ofLocale(locale),
+                    locale,
+                ),
+            )
+
+            return DisplayableDateTimeFormatter(dateFormatter, timeFormatter)
+        }
+    }
+}

--- a/feature/community/src/main/res/values/strings.xml
+++ b/feature/community/src/main/res/values/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="community_title">다른 사람 글</string>
+    <string name="community_list_card_create_date">공유 날짜</string>
+    <string name="community_list_card_create_at">공유 시각</string>
+    <string name="community_list_diary_card_like">좋아요</string>
+    <string name="community_list_diary_card_comment">댓글</string>
 </resources>


### PR DESCRIPTION
closes #187 

## :man_shrugging: Description

- [x] 커뮤니티 일기 카드 구현

to. 디자이너님  
댓클 버튼이랑 좋아요 버튼 순서를 figma랑 다르게 했어요  
댓글 개수에 따라 버튼 위치가 움직이는게 화가 막 나더라구요

좋아요가 오른쪽에 가려면 차라리 오른쪽 정렬이 나은 듯?

## :camera: Screenshots

![image](https://github.com/user-attachments/assets/2c28ecdc-ae8a-4eb7-a26d-d0dfa335997b)
