### PR TITLE
[feat] 동기화 functions needSync와의 로직

### DIFF
--- a/core/data/schema/com.boostcamp.dreamteam.dreamdiary.core.data.database.DreamDiaryDatabase/1.json
+++ b/core/data/schema/com.boostcamp.dreamteam.dreamdiary.core.data.database.DreamDiaryDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "bbb78f97c81991973cd786ef39ddae2a",
+    "identityHash": "9fae95dfb9602b465e712740b14cc2c4",
     "entities": [
       {
         "tableName": "diary",
@@ -273,12 +273,66 @@
         },
         "indices": [],
         "foreignKeys": []
+      },
+      {
+        "tableName": "synchronizing_label",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `diaryId` TEXT NOT NULL, FOREIGN KEY(`diaryId`) REFERENCES `synchronizing_diary`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "diaryId",
+            "columnName": "diaryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_synchronizing_label_diaryId",
+            "unique": false,
+            "columnNames": [
+              "diaryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_synchronizing_label_diaryId` ON `${TABLE_NAME}` (`diaryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "synchronizing_diary",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "diaryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bbb78f97c81991973cd786ef39ddae2a')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9fae95dfb9602b465e712740b14cc2c4')"
     ]
   }
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/DreamDiaryDatabase.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/DreamDiaryDatabase.kt
@@ -9,6 +9,7 @@ import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryLab
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.ImageEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingDreamDiaryEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingLabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.TextEntity
 
 @Database(
@@ -19,6 +20,7 @@ import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.TextEntity
         TextEntity::class,
         ImageEntity::class,
         SynchronizingDreamDiaryEntity::class,
+        SynchronizingLabelEntity::class,
     ],
     version = 1,
 )

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
@@ -10,8 +10,10 @@ import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryEnt
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryLabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryWithLabels
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.ImageEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.InsertSynchronizingLabel
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingDreamDiaryEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingLabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.TextEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.synchronization.DreamDiaryOnlyVersion
 import kotlinx.coroutines.flow.Flow
@@ -256,5 +258,72 @@ interface DreamDiaryDao {
                 needData = true,
             ),
         )
+    }
+
+    @Transaction
+    @Query("select * from diary where needSync = 1 or lastSyncVersion != currentVersion")
+    suspend fun getDreamDiaryNeedSync(): List<DreamDiaryWithLabels>
+
+    @Transaction
+    @Query("select * from synchronizing_diary where needData = 1")
+    suspend fun getSynchronizingDreamDiaryNeedData(): List<SynchronizingDreamDiaryEntity>
+
+    @Query("delete from synchronizing_diary where id = :id")
+    suspend fun deleteSynchronizingDreamDiary(id: String): Int
+
+    @Transaction
+    suspend fun deleteDreamDiaryHard(diaryId: String) {
+        deleteDreamDiaryLabels(diaryId = diaryId)
+        privateDeleteDreamDiaryHard(diaryId)
+        deleteSynchronizingDreamDiary(diaryId)
+    }
+
+    @Query("delete from diary where id = :id")
+    suspend fun privateDeleteDreamDiaryHard(id: String)
+
+    @Insert(entity = SynchronizingLabelEntity::class, onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSynchronizingLabel(insertLabel: InsertSynchronizingLabel)
+
+    @Query("delete from synchronizing_label where diaryId = :diaryId")
+    suspend fun deleteSynchronizingLabelOfDiaryId(diaryId: String)
+
+    @Query("update diary set lastSyncVersion = :version, currentVersion = :version, needSync = 0 where id = :id")
+    suspend fun updateDreamDiarySyncVersionAndCurrentVersion(id: String, version: String)
+
+    @Transaction
+    suspend fun insertSynchronizingDreamDiaryAndUpdateVersion(
+        id: String,
+        title: String,
+        body: String,
+        labels: List<String>,
+        createdAt: Instant,
+        updatedAt: Instant,
+        sleepStartAt: Instant,
+        sleepEndAt: Instant,
+        version: String,
+    ) {
+        insertSynchronizingDreamDiary(
+            SynchronizingDreamDiaryEntity(
+                id = id,
+                title = title,
+                body = body,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+                sleepStartAt = sleepStartAt,
+                sleepEndAt = sleepEndAt,
+                version = version,
+                needData = false,
+            )
+        )
+        deleteSynchronizingLabelOfDiaryId(diaryId = id)
+        for (label in labels) {
+            insertSynchronizingLabel(
+                InsertSynchronizingLabel(
+                    name = label,
+                    diaryId = id,
+                )
+            )
+        }
+        updateDreamDiarySyncVersionAndCurrentVersion(id, version)
     }
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
@@ -288,7 +288,10 @@ interface DreamDiaryDao {
     suspend fun deleteSynchronizingLabelOfDiaryId(diaryId: String)
 
     @Query("update diary set lastSyncVersion = :version, currentVersion = :version, needSync = 0 where id = :id")
-    suspend fun updateDreamDiarySyncVersionAndCurrentVersion(id: String, version: String)
+    suspend fun updateDreamDiarySyncVersionAndCurrentVersion(
+        id: String,
+        version: String,
+    )
 
     @Transaction
     suspend fun insertSynchronizingDreamDiaryAndUpdateVersion(
@@ -313,7 +316,7 @@ interface DreamDiaryDao {
                 sleepEndAt = sleepEndAt,
                 version = version,
                 needData = false,
-            )
+            ),
         )
         deleteSynchronizingLabelOfDiaryId(diaryId = id)
         for (label in labels) {
@@ -321,7 +324,7 @@ interface DreamDiaryDao {
                 InsertSynchronizingLabel(
                     name = label,
                     diaryId = id,
-                )
+                ),
             )
         }
         updateDreamDiarySyncVersionAndCurrentVersion(id, version)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/SynchronizingLabelEntity.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/SynchronizingLabelEntity.kt
@@ -8,9 +8,14 @@ import androidx.room.PrimaryKey
 @Entity(
     tableName = "synchronizing_label",
     foreignKeys = [
-        ForeignKey(entity = SynchronizingDreamDiaryEntity::class, parentColumns = ["id"], childColumns = ["diaryId"], onDelete = ForeignKey.CASCADE),
+        ForeignKey(
+            entity = SynchronizingDreamDiaryEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["diaryId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
     ],
-    indices = [Index("diaryId")]
+    indices = [Index("diaryId")],
 )
 data class SynchronizingLabelEntity(
     @PrimaryKey(autoGenerate = true)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/SynchronizingLabelEntity.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/SynchronizingLabelEntity.kt
@@ -1,0 +1,25 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.database.model
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "synchronizing_label",
+    foreignKeys = [
+        ForeignKey(entity = SynchronizingDreamDiaryEntity::class, parentColumns = ["id"], childColumns = ["diaryId"], onDelete = ForeignKey.CASCADE),
+    ],
+    indices = [Index("diaryId")]
+)
+data class SynchronizingLabelEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long,
+    val name: String,
+    val diaryId: String,
+)
+
+data class InsertSynchronizingLabel(
+    val name: String,
+    val diaryId: String,
+)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsSyncVersionRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsSyncVersionRequest.kt
@@ -14,7 +14,7 @@ data class FunctionsSyncVersionRequest(
     )
 }
 
-fun SyncVersionRequest.toDreamDiarySyncVersion(): FunctionsSyncVersionRequest.IdAndVersion {
+fun SyncVersionRequest.toFunctionsRequest(): FunctionsSyncVersionRequest.IdAndVersion {
     return FunctionsSyncVersionRequest.IdAndVersion(
         diaryId = this.id,
         version = this.version,

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsSynchronizeDiaryRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsSynchronizeDiaryRequest.kt
@@ -1,0 +1,40 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model
+
+import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SynchronizeDreamDiaryRequest
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FunctionsSynchronizeDiaryRequest(
+    val list: List<DreamDiary>
+) {
+    @Serializable
+    data class DreamDiary(
+        val diaryId: String,
+        val title: String,
+        val content: String,
+        val createdAt: Long,
+        val updatedAt: Long,
+        val deletedAt: Long?,
+        val sleepStartAt: Long,
+        val sleepEndAt: Long,
+        val labels: List<String>,
+        val previousVersion: String,
+        val currentVersion: String,
+    )
+}
+
+fun SynchronizeDreamDiaryRequest.toFunctionsRequest(): FunctionsSynchronizeDiaryRequest.DreamDiary {
+    return FunctionsSynchronizeDiaryRequest.DreamDiary(
+        diaryId = this.id,
+        title = this.title,
+        content = this.content,
+        createdAt = this.createdAt.toEpochMilli(),
+        updatedAt = this.updatedAt.toEpochMilli(),
+        deletedAt = this.deletedAt?.toEpochMilli(),
+        sleepStartAt = this.sleepStartAt.toEpochMilli(),
+        sleepEndAt = this.sleepEndAt.toEpochMilli(),
+        labels = this.labels,
+        previousVersion = this.previousVersion,
+        currentVersion = this.currentVersion,
+    )
+}

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsSynchronizeDiaryRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsSynchronizeDiaryRequest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class FunctionsSynchronizeDiaryRequest(
-    val list: List<DreamDiary>
+    val list: List<DreamDiary>,
 ) {
     @Serializable
     data class DreamDiary(

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
@@ -81,7 +81,7 @@ class FunctionRepository @Inject constructor(
                         sleepStartAt = newDiaryResponse["sleepStartAt"] as Long,
                         title = newDiaryResponse["title"] as String,
                         updatedAt = newDiaryResponse["updatedAt"] as Long,
-                        content = newDiaryResponse["content"] as String
+                        content = newDiaryResponse["content"] as String,
                     )
                 } else {
                     null
@@ -95,7 +95,7 @@ class FunctionRepository @Inject constructor(
                         sleepStartAt = updateDiaryResponse["sleepStartAt"] as Long,
                         title = updateDiaryResponse["title"] as String,
                         updatedAt = updateDiaryResponse["updatedAt"] as Long,
-                        content = updateDiaryResponse["content"] as String
+                        content = updateDiaryResponse["content"] as String,
                     )
                 } else {
                     null
@@ -103,7 +103,7 @@ class FunctionRepository @Inject constructor(
                 val deletedDiary = if ("deletedDiary" in response) {
                     val deletedDiaryResponse = response["deletedDiary"] as Map<String, Any>
                     SynchronizeDreamDiaryResponse.DeletedDiary(
-                        deleted = deletedDiaryResponse["deleted"] as Boolean
+                        deleted = deletedDiaryResponse["deleted"] as Boolean,
                     )
                 } else {
                     null

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
@@ -2,9 +2,11 @@ package com.boostcamp.dreamteam.dreamdiary.core.data.repository
 
 import com.boostcamp.dreamteam.dreamdiary.core.data.convertToFirebaseData
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.FunctionsSyncVersionRequest
-import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.toDreamDiarySyncVersion
+import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.toFunctionsRequest
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SyncVersionRequest
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SyncVersionResponse
+import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SynchronizeDreamDiaryRequest
+import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SynchronizeDreamDiaryResponse
 import com.google.firebase.functions.FirebaseFunctions
 import kotlinx.coroutines.tasks.await
 import kotlinx.serialization.json.Json
@@ -18,7 +20,7 @@ class FunctionRepository @Inject constructor(
 ) {
     suspend fun syncVersion(syncVersions: List<SyncVersionRequest>): SyncVersionResponse? {
         val data = FunctionsSyncVersionRequest(
-            list = syncVersions.map { it.toDreamDiarySyncVersion() },
+            list = syncVersions.map { it.toFunctionsRequest() },
         )
         val jsonData = Json.encodeToJsonElement(data).jsonObject.convertToFirebaseData()
 
@@ -52,6 +54,68 @@ class FunctionRepository @Inject constructor(
             )
         }
 
+        return null
+    }
+
+    suspend fun synchronizeDreamDiary(diary: SynchronizeDreamDiaryRequest): SynchronizeDreamDiaryResponse? {
+        val diarySync = diary.toFunctionsRequest()
+        val jsonData = Json.encodeToJsonElement(diarySync).jsonObject.convertToFirebaseData()
+
+        val response = functions
+            .getHttpsCallable("needSync")
+            .call(jsonData)
+            .await()
+            .data
+
+        Timber.d("needSync response $response")
+
+        if (response != null) {
+            val response = response as Map<String, Any>
+            if (response["isSuccess"] == true) {
+                val newDiary = if ("newDiary" in response) {
+                    val newDiaryResponse = response["newDiary"] as Map<String, Any>
+                    SynchronizeDreamDiaryResponse.NewDiary(
+                        createdAt = newDiaryResponse["createdAt"] as Long,
+                        labels = newDiaryResponse["labels"] as List<String>,
+                        sleepEndAt = newDiaryResponse["sleepEndAt"] as Long,
+                        sleepStartAt = newDiaryResponse["sleepStartAt"] as Long,
+                        title = newDiaryResponse["title"] as String,
+                        updatedAt = newDiaryResponse["updatedAt"] as Long,
+                        content = newDiaryResponse["content"] as String
+                    )
+                } else {
+                    null
+                }
+                val updateDiary = if ("updateDiary" in response) {
+                    val updateDiaryResponse = response["updateDiary"] as Map<String, Any>
+                    SynchronizeDreamDiaryResponse.UpdateDiary(
+                        createdAt = updateDiaryResponse["createdAt"] as Long,
+                        labels = updateDiaryResponse["labels"] as List<String>,
+                        sleepEndAt = updateDiaryResponse["sleepEndAt"] as Long,
+                        sleepStartAt = updateDiaryResponse["sleepStartAt"] as Long,
+                        title = updateDiaryResponse["title"] as String,
+                        updatedAt = updateDiaryResponse["updatedAt"] as Long,
+                        content = updateDiaryResponse["content"] as String
+                    )
+                } else {
+                    null
+                }
+                val deletedDiary = if ("deletedDiary" in response) {
+                    val deletedDiaryResponse = response["deletedDiary"] as Map<String, Any>
+                    SynchronizeDreamDiaryResponse.DeletedDiary(
+                        deleted = deletedDiaryResponse["deleted"] as Boolean
+                    )
+                } else {
+                    null
+                }
+                return SynchronizeDreamDiaryResponse(
+                    currentVersion = response["currentVersion"] as String,
+                    newDiary = newDiary,
+                    updateDiary = updateDiary,
+                    deletedDiary = deletedDiary,
+                )
+            }
+        }
         return null
     }
 }

--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/SynchronizeDreamDiaryRequest.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/SynchronizeDreamDiaryRequest.kt
@@ -1,0 +1,24 @@
+package com.boostcamp.dreamteam.dreamdiary.core.model.synchronization
+
+import java.time.Instant
+
+data class SynchronizeDreamDiaryRequest(
+    val id: String,
+    val title: String,
+    val content: String,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant?,
+    val sleepStartAt: Instant,
+    val sleepEndAt: Instant,
+    val labels: List<String>,
+    val diaryContents: List<ContentId>,
+    val previousVersion: String,
+    val currentVersion: String,
+) {
+    sealed class ContentId {
+        data class Image(val id: String) : ContentId()
+        data class Text(val id: String) : ContentId()
+    }
+}
+

--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/SynchronizeDreamDiaryRequest.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/SynchronizeDreamDiaryRequest.kt
@@ -18,7 +18,7 @@ data class SynchronizeDreamDiaryRequest(
 ) {
     sealed class ContentId {
         data class Image(val id: String) : ContentId()
+
         data class Text(val id: String) : ContentId()
     }
 }
-

--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/SynchronizeDreamDiaryResponse.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/SynchronizeDreamDiaryResponse.kt
@@ -15,6 +15,7 @@ data class SynchronizeDreamDiaryResponse(
         val updatedAt: Long,
         val content: String,
     )
+
     data class UpdateDiary(
         val createdAt: Long,
         val labels: List<String>,
@@ -24,6 +25,7 @@ data class SynchronizeDreamDiaryResponse(
         val updatedAt: Long,
         val content: String,
     )
+
     data class DeletedDiary(
         val deleted: Boolean,
     )

--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/SynchronizeDreamDiaryResponse.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/SynchronizeDreamDiaryResponse.kt
@@ -1,0 +1,30 @@
+package com.boostcamp.dreamteam.dreamdiary.core.model.synchronization
+
+data class SynchronizeDreamDiaryResponse(
+    val currentVersion: String,
+    val newDiary: NewDiary?,
+    val updateDiary: UpdateDiary?,
+    val deletedDiary: DeletedDiary?,
+) {
+    data class NewDiary(
+        val createdAt: Long,
+        val labels: List<String>,
+        val sleepEndAt: Long,
+        val sleepStartAt: Long,
+        val title: String,
+        val updatedAt: Long,
+        val content: String,
+    )
+    data class UpdateDiary(
+        val createdAt: Long,
+        val labels: List<String>,
+        val sleepEndAt: Long,
+        val sleepStartAt: Long,
+        val title: String,
+        val updatedAt: Long,
+        val content: String,
+    )
+    data class DeletedDiary(
+        val deleted: Boolean,
+    )
+}

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/Mapper.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/Mapper.kt
@@ -1,0 +1,68 @@
+package com.boostcamp.dreamteam.dreamdiary.core.synchronization
+
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryWithLabels
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingDreamDiaryEntity
+import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SynchronizeDreamDiaryRequest
+
+internal fun SynchronizingDreamDiaryEntity.toRequest(): SynchronizeDreamDiaryRequest {
+    return SynchronizeDreamDiaryRequest(
+        id = this.id,
+        title = this.title,
+        content = this.body,
+        createdAt = this.createdAt,
+        updatedAt = this.updatedAt,
+        deletedAt = null,
+        sleepStartAt = this.sleepStartAt,
+        sleepEndAt = this.sleepEndAt,
+        labels = emptyList(),
+        diaryContents = emptyList(),
+        previousVersion = this.version,
+        currentVersion = this.version
+    )
+}
+
+internal fun DreamDiaryWithLabels.toRequest(): SynchronizeDreamDiaryRequest {
+    return SynchronizeDreamDiaryRequest(
+        id = dreamDiary.id,
+        title = dreamDiary.title,
+        content = dreamDiary.body,
+        createdAt = dreamDiary.createdAt,
+        updatedAt = dreamDiary.updatedAt,
+        deletedAt = dreamDiary.deletedAt,
+        labels = this.labels.map { it.label },
+        sleepStartAt = dreamDiary.sleepStartAt,
+        sleepEndAt = dreamDiary.sleepEndAt,
+        diaryContents = parseBodyOnlyId(this.dreamDiary.body),
+        previousVersion = this.dreamDiary.lastSyncVersion,
+        currentVersion = this.dreamDiary.currentVersion,
+    )
+}
+
+private fun parseBodyOnlyId(body: String): List<SynchronizeDreamDiaryRequest.ContentId> {
+    val diaryContents = mutableListOf<SynchronizeDreamDiaryRequest.ContentId>()
+
+    val parsingDiaryContent = body.split(":")
+    var index = 0
+
+    while (index < parsingDiaryContent.size) {
+        if (parsingDiaryContent[index] == "text") {
+            index += 1
+            diaryContents.add(
+                SynchronizeDreamDiaryRequest.ContentId.Text(
+                    id = parsingDiaryContent[index],
+                ),
+            )
+        } else if (parsingDiaryContent[index] == "image") {
+            index += 1
+            diaryContents.add(
+                SynchronizeDreamDiaryRequest.ContentId.Image(
+                    id = parsingDiaryContent[index],
+                ),
+            )
+        } else {
+            index += 1
+            continue
+        }
+    }
+    return diaryContents
+}

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/Mapper.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/Mapper.kt
@@ -17,7 +17,7 @@ internal fun SynchronizingDreamDiaryEntity.toRequest(): SynchronizeDreamDiaryReq
         labels = emptyList(),
         diaryContents = emptyList(),
         previousVersion = this.version,
-        currentVersion = this.version
+        currentVersion = this.version,
     )
 }
 

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
@@ -11,11 +11,8 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.dao.DreamDiaryDao
-import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryWithLabels
-import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingDreamDiaryEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.repository.FunctionRepository
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SyncVersionRequest
-import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SynchronizeDreamDiaryRequest
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import dagger.hilt.EntryPoint

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
@@ -11,8 +11,11 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.dao.DreamDiaryDao
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryWithLabels
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingDreamDiaryEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.repository.FunctionRepository
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SyncVersionRequest
+import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SynchronizeDreamDiaryRequest
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import dagger.hilt.EntryPoint
@@ -22,6 +25,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.time.Instant
 
 @HiltWorker
 class SynchronizationWorker @AssistedInject constructor(
@@ -34,6 +38,7 @@ class SynchronizationWorker @AssistedInject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 synchronizeVersion()
+                synchronizeDreamDiaries()
                 Result.success()
             } catch (e: Exception) {
                 Timber.e(e, "SynchronizationWorker")
@@ -65,6 +70,58 @@ class SynchronizationWorker @AssistedInject constructor(
 
             for (i in syncResponse.serverOnlyDiaries) {
                 dreamDiaryDao.insertSynchronizingDreamDiary(i.diaryId, "init")
+            }
+        }
+    }
+
+    private suspend fun synchronizeDreamDiaries() {
+        val synchronizingDreamDiaryNeedData = dreamDiaryDao.getSynchronizingDreamDiaryNeedData()
+        val dreamDiaryNeedSync = dreamDiaryDao.getDreamDiaryNeedSync()
+
+        val synchronizeDreamDiaries =
+            synchronizingDreamDiaryNeedData.map { it.toRequest() } + dreamDiaryNeedSync.map { it.toRequest() }
+
+        for (dreamDiary in synchronizeDreamDiaries) {
+            val response = functionRepository.synchronizeDreamDiary(dreamDiary)
+
+            if (response != null) {
+                val newDiary = response.newDiary
+                val updateDiary = response.updateDiary
+                val deletedDiary = response.deletedDiary
+                if (deletedDiary != null) {
+                    if (deletedDiary.deleted) {
+                        dreamDiaryDao.deleteDreamDiaryHard(dreamDiary.id)
+                        continue
+                    }
+                }
+
+                if (newDiary != null) {
+                    dreamDiaryDao.insertSynchronizingDreamDiaryAndUpdateVersion(
+                        id = dreamDiary.id,
+                        title = newDiary.title,
+                        body = newDiary.content,
+                        labels = newDiary.labels,
+                        createdAt = Instant.ofEpochMilli(newDiary.createdAt),
+                        updatedAt = Instant.ofEpochMilli(newDiary.updatedAt),
+                        sleepStartAt = Instant.ofEpochMilli(newDiary.sleepStartAt),
+                        sleepEndAt = Instant.ofEpochMilli(newDiary.sleepEndAt),
+                        version = response.currentVersion,
+                    )
+                } else if (updateDiary != null) {
+                    dreamDiaryDao.insertSynchronizingDreamDiaryAndUpdateVersion(
+                        id = dreamDiary.id,
+                        title = updateDiary.title,
+                        body = updateDiary.content,
+                        labels = updateDiary.labels,
+                        createdAt = Instant.ofEpochMilli(updateDiary.createdAt),
+                        updatedAt = Instant.ofEpochMilli(updateDiary.updatedAt),
+                        sleepStartAt = Instant.ofEpochMilli(updateDiary.sleepStartAt),
+                        sleepEndAt = Instant.ofEpochMilli(updateDiary.sleepEndAt),
+                        version = response.currentVersion,
+                    )
+                } else {
+                    dreamDiaryDao.updateDreamDiarySyncVersionAndCurrentVersion(dreamDiary.id, response.currentVersion)
+                }
             }
         }
     }


### PR DESCRIPTION
## :man_shrugging: Description

Content(텍스트 내용, 이미지 path 및 이미지 데이터)를 제외하고 서버와 동기화 합니다.
앞서 versionCheck를 통해 서버가 알려준 동기화 해야 하는 꿈일기 및 클라이언트에서 수정된 꿈일기를 서버에게 전송합니다.
Content가 없는 꿈일기는 아직 동기화가 끝나지 않았으므로, synchronizing_diary 테이블에 계속 보관합니다.