### PR TITLE
[feat] functions uploadText, uploadImage와의 로직 추가

### DIFF
--- a/core/data/schema/com.boostcamp.dreamteam.dreamdiary.core.data.database.DreamDiaryDatabase/1.json
+++ b/core/data/schema/com.boostcamp.dreamteam.dreamdiary.core.data.database.DreamDiaryDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "9fae95dfb9602b465e712740b14cc2c4",
+    "identityHash": "04358764186e5b30e5bc6ada9501e01c",
     "entities": [
       {
         "tableName": "diary",
@@ -327,12 +327,66 @@
             ]
           }
         ]
+      },
+      {
+        "tableName": "synchronizing_content",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `diaryId` TEXT NOT NULL, `needUpload` INTEGER NOT NULL, `isDone` INTEGER NOT NULL, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "diaryId",
+            "columnName": "diaryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "needUpload",
+            "columnName": "needUpload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDone",
+            "columnName": "isDone",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_synchronizing_content_diaryId",
+            "unique": false,
+            "columnNames": [
+              "diaryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_synchronizing_content_diaryId` ON `${TABLE_NAME}` (`diaryId`)"
+          }
+        ],
+        "foreignKeys": []
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9fae95dfb9602b465e712740b14cc2c4')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '04358764186e5b30e5bc6ada9501e01c')"
     ]
   }
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/DreamDiaryDatabase.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/DreamDiaryDatabase.kt
@@ -8,6 +8,7 @@ import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryEnt
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryLabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.ImageEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingContentEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingDreamDiaryEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingLabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.TextEntity
@@ -21,6 +22,7 @@ import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.TextEntity
         ImageEntity::class,
         SynchronizingDreamDiaryEntity::class,
         SynchronizingLabelEntity::class,
+        SynchronizingContentEntity::class,
     ],
     version = 1,
 )

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
@@ -338,7 +338,11 @@ interface DreamDiaryDao {
     suspend fun getSynchronizingContent(id: String): SynchronizingContentEntity?
 
     @Transaction
-    suspend fun insertSynchronizingContentWhenNotDone(contentId: String, diaryId: String, type: String) {
+    suspend fun insertSynchronizingContentWhenNotDone(
+        contentId: String,
+        diaryId: String,
+        type: String,
+    ) {
         val synchronizingContent = getSynchronizingContent(contentId)
         if (synchronizingContent == null || !synchronizingContent.isDone) {
             insertSynchronizingContent(
@@ -348,7 +352,7 @@ interface DreamDiaryDao {
                     needUpload = true,
                     isDone = false,
                     type = type,
-                )
+                ),
             )
         }
     }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
@@ -12,6 +12,7 @@ import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.DreamDiaryWit
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.ImageEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.InsertSynchronizingLabel
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.LabelEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingContentEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingDreamDiaryEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingLabelEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.TextEntity
@@ -329,4 +330,32 @@ interface DreamDiaryDao {
         }
         updateDreamDiarySyncVersionAndCurrentVersion(id, version)
     }
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSynchronizingContent(content: SynchronizingContentEntity)
+
+    @Query("select * from synchronizing_content where id = :id")
+    suspend fun getSynchronizingContent(id: String): SynchronizingContentEntity?
+
+    @Transaction
+    suspend fun insertSynchronizingContentWhenNotDone(contentId: String, diaryId: String, type: String) {
+        val synchronizingContent = getSynchronizingContent(contentId)
+        if (synchronizingContent == null || !synchronizingContent.isDone) {
+            insertSynchronizingContent(
+                SynchronizingContentEntity(
+                    id = contentId,
+                    diaryId = diaryId,
+                    needUpload = true,
+                    isDone = false,
+                    type = type,
+                )
+            )
+        }
+    }
+
+    @Query("select * from synchronizing_content where needUpload = 1 and isDone = 0")
+    suspend fun getNeedSynchronizingContents(): List<SynchronizingContentEntity>
+
+    @Query("update synchronizing_content set isDone = 1 where id = :id")
+    suspend fun setSynchronizingContentDone(id: String)
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/SynchronizingContentEntity.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/SynchronizingContentEntity.kt
@@ -1,0 +1,18 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.database.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "synchronizing_content",
+    indices = [Index("diaryId")],
+)
+data class SynchronizingContentEntity(
+    @PrimaryKey
+    val id: String,
+    val diaryId: String,
+    val needUpload: Boolean,
+    val isDone: Boolean,
+    val type: String,
+)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsUploadImageContentRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsUploadImageContentRequest.kt
@@ -1,5 +1,8 @@
 package com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class FunctionsUploadImageContentRequest(
     val id: String,
     val path: String,

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsUploadImageContentRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsUploadImageContentRequest.kt
@@ -1,0 +1,6 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model
+
+data class FunctionsUploadImageContentRequest(
+    val id: String,
+    val path: String,
+)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsUploadTextContentRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsUploadTextContentRequest.kt
@@ -1,5 +1,8 @@
 package com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class FunctionsUploadTextContentRequest(
     val id: String,
     val text: String,

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsUploadTextContentRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsUploadTextContentRequest.kt
@@ -1,0 +1,6 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model
+
+data class FunctionsUploadTextContentRequest(
+    val id: String,
+    val text: String,
+)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
@@ -131,7 +131,10 @@ class FunctionRepository @Inject constructor(
         return null
     }
 
-    suspend fun uploadText(id: String, text: String): Boolean {
+    suspend fun uploadText(
+        id: String,
+        text: String,
+    ): Boolean {
         val jsonData =
             Json.encodeToJsonElement(FunctionsUploadTextContentRequest(id, text)).jsonObject.convertToFirebaseData()
 
@@ -149,7 +152,10 @@ class FunctionRepository @Inject constructor(
         }
     }
 
-    suspend fun uploadImage(id: String, path: String): Boolean {
+    suspend fun uploadImage(
+        id: String,
+        path: String,
+    ): Boolean {
         val jsonData =
             Json.encodeToJsonElement(FunctionsUploadImageContentRequest(id, path)).jsonObject.convertToFirebaseData()
 

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/component/DiaryContentEditor.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/component/DiaryContentEditor.kt
@@ -37,6 +37,7 @@ import com.boostcamp.dreamteam.dreamdiary.designsystem.component.DdAsyncImage
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryContentUi
+import java.io.File
 
 @Composable
 internal fun DiaryContentEditor(
@@ -131,8 +132,11 @@ private fun BodyImage(
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
+        val context = LocalContext.current
         DdAsyncImage(
-            model = ImageRequest.Builder(LocalContext.current).data(diaryContent.path).build(),
+            model = ImageRequest.Builder(context)
+                .data(File(context.filesDir, diaryContent.path).path)
+                .build(),
             contentDescription = stringResource(R.string.write_content_image),
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/detail/DiaryDetailScreen.kt
@@ -41,6 +41,7 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryContentUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.LabelUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.filteredLabelsPreview
 import timber.log.Timber
+import java.io.File
 import java.time.ZonedDateTime
 
 @Composable
@@ -201,10 +202,11 @@ internal fun DiaryDetailContent(
                 }
 
                 is DiaryContentUi.Image -> {
+                    val context = LocalContext.current
                     AsyncImage(
                         model = ImageRequest
-                            .Builder(LocalContext.current)
-                            .data(diaryContent.path)
+                            .Builder(context)
+                            .data(File(context.filesDir, diaryContent.path).path)
                             .build(),
                         contentDescription = "aaaa",
                         modifier = Modifier

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCard.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -36,6 +37,7 @@ import com.boostcamp.dreamteam.dreamdiary.feature.diary.R
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.component.DiaryMenuButton
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.DiaryUi
 import com.boostcamp.dreamteam.dreamdiary.feature.diary.model.diaryPreview1
+import java.io.File
 import java.time.chrono.Chronology
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
@@ -101,8 +103,9 @@ private fun CardOverline(
     modifier: Modifier = Modifier,
 ) {
     diary.images.firstOrNull()?.let {
+        val context = LocalContext.current
         DdAsyncImage(
-            model = it,
+            model = File(context.filesDir, it).path,
             contentDescription = stringResource(R.string.home_list_card_thumbnail, diary.title),
             contentScale = ContentScale.Crop,
             modifier = modifier,

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
@@ -187,8 +187,9 @@ private fun DiaryWriteScreenContent(
             uri?.let {
                 context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 coroutineScope.launch(Dispatchers.IO) {
+                    val fileName = UUID.randomUUID().toString()
                     val inputStream = context.contentResolver.openInputStream(uri)
-                    val outputFile = File(context.filesDir, UUID.randomUUID().toString())
+                    val outputFile = File(context.filesDir, fileName)
                     val outputStream = FileOutputStream(outputFile)
 
                     inputStream?.use { input ->
@@ -201,7 +202,7 @@ private fun DiaryWriteScreenContent(
                         onContentImageAdd(
                             currentFocusContent,
                             currentTextCursorPosition,
-                            outputFile.path,
+                            fileName,
                         )
                     }
                 }


### PR DESCRIPTION
## :man_shrugging: Description
업로드 해야 하는 꿈일기의 컨텐트(텍스트 내용, 이미지 데이터)를 찾고 이를 업로드합니다.
업로드 해야 하는 컨텐트를 보관하는 새로운 엔티티 SynchronizingContentEntity를 생성했습니다.
needSync(#201)의 호출 전, SynchronizingContentEntity에 업로드 해야 하는 컨텐트를 먼저 보관합니다.

기존에 이미지를 룸 DB에 저장할 때 full path를 함께 저장했으나, 파일 이름만 저장하고 path를 사용하는 쪽에서 `Context.filesDir`를 붙이게 변경하였습니다.
