### PR TITLE
[feat] functions dowloadImage, downloadText와의 로직

### DIFF
--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
@@ -431,7 +431,7 @@ interface DreamDiaryDao {
                 needSync = false,
                 lastSyncVersion = synchronizingDreamDiary.version,
                 currentVersion = synchronizingDreamDiary.version,
-            )
+            ),
         )
         deleteDreamDiaryLabels(synchronizingDreamDiary.id)
         setLabelsToDreamDiary(

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/dao/DreamDiaryDao.kt
@@ -443,4 +443,16 @@ interface DreamDiaryDao {
 
     @Query("select * from synchronizing_diary")
     suspend fun getSynchronizingDreamDiaries(): List<SynchronizingDreamDiaryEntity>
+
+    @Transaction
+    suspend fun removeSyncData() {
+        deleteAllSynchronizingDreamDiary()
+        deleteAllSynchronizingContent()
+    }
+
+    @Query("delete from synchronizing_diary")
+    suspend fun deleteAllSynchronizingDreamDiary(): Int
+
+    @Query("delete from synchronizing_content")
+    suspend fun deleteAllSynchronizingContent(): Int
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/SynchronizingDreamDiaryEntity.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/database/model/SynchronizingDreamDiaryEntity.kt
@@ -1,7 +1,9 @@
 package com.boostcamp.dreamteam.dreamdiary.core.data.database.model
 
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import androidx.room.Relation
 import java.time.Instant
 
 @Entity(
@@ -18,4 +20,13 @@ data class SynchronizingDreamDiaryEntity(
     val sleepEndAt: Instant,
     val version: String,
     val needData: Boolean,
+)
+
+data class SynchronizingDreamDiaryWithLabels(
+    @Embedded val diary: SynchronizingDreamDiaryEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "diaryId",
+    )
+    val labels: List<SynchronizingLabelEntity>,
 )

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsDownloadImageContentRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsDownloadImageContentRequest.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FunctionsDownloadImageContentRequest(
+    val id: String,
+)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsDownloadTextContentRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/functions/model/FunctionsDownloadTextContentRequest.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FunctionsDownloadTextContentRequest(
+    val id: String,
+)

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
@@ -1,6 +1,7 @@
 package com.boostcamp.dreamteam.dreamdiary.core.data.repository
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.core.net.toUri
 import com.boostcamp.dreamteam.dreamdiary.core.data.convertToFirebaseData
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.FunctionsDownloadImageContentRequest
@@ -31,8 +32,19 @@ class FunctionRepository @Inject constructor(
     private val functions: FirebaseFunctions,
     private val storage: FirebaseStorage,
     @ApplicationContext private val applicationContext: Context,
+    private val sharedPreferences: SharedPreferences,
 ) {
     private val firebaseAuth: FirebaseAuth = FirebaseAuth.getInstance()
+
+    fun updateCurrentUID(): Boolean {
+        val lastSyncUID = sharedPreferences.getString("last_sync_UID", null)
+        if (lastSyncUID != firebaseAuth.uid) {
+            sharedPreferences.edit().putString("last_sync_UID", firebaseAuth.uid).apply()
+            return true
+        } else {
+            return false
+        }
+    }
 
     suspend fun syncVersion(syncVersions: List<SyncVersionRequest>): SyncVersionResponse? {
         val data = FunctionsSyncVersionRequest(

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/FunctionRepository.kt
@@ -6,12 +6,12 @@ import androidx.core.net.toUri
 import com.boostcamp.dreamteam.dreamdiary.core.data.convertToFirebaseData
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.FunctionsDownloadImageContentRequest
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.FunctionsDownloadTextContentRequest
-import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.DownloadTextResponse
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.FunctionsSyncVersionRequest
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.FunctionsUploadImageContentRequest
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.FunctionsUploadTextContentRequest
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.functions.model.toFunctionsRequest
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.DownloadImageResponse
+import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.DownloadTextResponse
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SyncVersionRequest
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SyncVersionResponse
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SynchronizeDreamDiaryRequest
@@ -199,7 +199,6 @@ class FunctionRepository @Inject constructor(
         return false
     }
 
-
     suspend fun downloadText(id: String): DownloadTextResponse? {
         val jsonData =
             Json.encodeToJsonElement(FunctionsDownloadTextContentRequest(id)).jsonObject.convertToFirebaseData()
@@ -223,7 +222,6 @@ class FunctionRepository @Inject constructor(
         }
         return null
     }
-
 
     suspend fun downloadImage(id: String): DownloadImageResponse? {
         val jsonData =
@@ -254,7 +252,7 @@ class FunctionRepository @Inject constructor(
 
                     return DownloadImageResponse(
                         contentId = id,
-                        path = path
+                        path = path,
                     )
                 }
             }

--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/DownloadImageResponse.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/DownloadImageResponse.kt
@@ -1,0 +1,6 @@
+package com.boostcamp.dreamteam.dreamdiary.core.model.synchronization
+
+data class DownloadImageResponse(
+    val contentId: String,
+    val path: String,
+)

--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/DownloadTextResponse.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/synchronization/DownloadTextResponse.kt
@@ -1,0 +1,6 @@
+package com.boostcamp.dreamteam.dreamdiary.core.model.synchronization
+
+data class DownloadTextResponse(
+    val contentId: String,
+    val text: String,
+)

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/NotDownloadedContent.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/NotDownloadedContent.kt
@@ -2,5 +2,6 @@ package com.boostcamp.dreamteam.dreamdiary.core.synchronization
 
 sealed class NotDownloadedContent {
     data class Text(val id: String, val diaryId: String) : NotDownloadedContent()
+
     data class Image(val id: String, val diaryId: String) : NotDownloadedContent()
 }

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/NotDownloadedContent.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/NotDownloadedContent.kt
@@ -1,0 +1,6 @@
+package com.boostcamp.dreamteam.dreamdiary.core.synchronization
+
+sealed class NotDownloadedContent {
+    data class Text(val id: String, val diaryId: String) : NotDownloadedContent()
+    data class Image(val id: String, val diaryId: String) : NotDownloadedContent()
+}

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
@@ -38,6 +38,11 @@ class SynchronizationWorker @AssistedInject constructor(
     override suspend fun doWork(): Result {
         return withContext(Dispatchers.IO) {
             try {
+                if (functionRepository.updateCurrentUID()) {
+                    Timber.d("remove all sync data")
+                    removeAllSyncData()
+                }
+
                 synchronizeVersion()
                 synchronizeDreamDiaries()
                 uploadContents()
@@ -232,6 +237,10 @@ class SynchronizationWorker @AssistedInject constructor(
             }
         }
         return diaryContents
+    }
+
+    private suspend fun removeAllSyncData() {
+        dreamDiaryDao.removeSyncData()
     }
 
     companion object {

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
@@ -11,6 +11,9 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.boostcamp.dreamteam.dreamdiary.core.data.database.dao.DreamDiaryDao
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.ImageEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.SynchronizingDreamDiaryEntity
+import com.boostcamp.dreamteam.dreamdiary.core.data.database.model.TextEntity
 import com.boostcamp.dreamteam.dreamdiary.core.data.repository.FunctionRepository
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SyncVersionRequest
 import com.boostcamp.dreamteam.dreamdiary.core.model.synchronization.SynchronizeDreamDiaryRequest
@@ -38,6 +41,7 @@ class SynchronizationWorker @AssistedInject constructor(
                 synchronizeVersion()
                 synchronizeDreamDiaries()
                 uploadContents()
+                downloadContents()
                 Result.success()
             } catch (e: Exception) {
                 Timber.e(e, "SynchronizationWorker")
@@ -153,6 +157,81 @@ class SynchronizationWorker @AssistedInject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun downloadContents() {
+        dreamDiaryDao.removeSynchronizingDreamDiaryIfVersionNotEquals()
+
+        val ids = dreamDiaryDao.getSynchronizingDreamDiaryIds()
+        for (id in ids) {
+            dreamDiaryDao.moveToDreamDiaryIfSynced(id)
+        }
+
+        val notDownloadedContents = dreamDiaryDao.getSynchronizingDreamDiaries().flatMap { diary ->
+            parseNeedDownloadContent(diary)
+        }
+
+        for (content in notDownloadedContents) {
+            when (content) {
+                is NotDownloadedContent.Image -> {
+                    val image = functionRepository.downloadImage(content.id)
+                    if (image != null) {
+                        dreamDiaryDao.insertImage(
+                            imageEntity = ImageEntity(
+                                id = content.id,
+                                path = image.path,
+                            )
+                        )
+                        dreamDiaryDao.moveToDreamDiaryIfSynced(content.diaryId)
+                    }
+                }
+                is NotDownloadedContent.Text -> {
+                    val text = functionRepository.downloadText(content.id)
+                    if (text != null) {
+                        dreamDiaryDao.insertText(
+                            textEntity = TextEntity(
+                                id = content.id,
+                                text = text.text
+                            )
+                        )
+                        dreamDiaryDao.moveToDreamDiaryIfSynced(content.diaryId)
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun parseNeedDownloadContent(synchronizingDreamDiaryEntity: SynchronizingDreamDiaryEntity): List<NotDownloadedContent> {
+        val body = synchronizingDreamDiaryEntity.body
+        val diaryContents = mutableListOf<NotDownloadedContent>()
+
+        val parsingDiaryContent = body.split(":")
+        var index = 0
+
+        while (index < parsingDiaryContent.size) {
+            if (parsingDiaryContent[index] == "text") {
+                index += 1
+                val id = parsingDiaryContent[index]
+                val textEntity = dreamDiaryDao.getText(id)
+                if (textEntity == null) {
+                    diaryContents.add(
+                        NotDownloadedContent.Text(id, synchronizingDreamDiaryEntity.id)
+                    )
+                }
+            } else if (parsingDiaryContent[index] == "image") {
+                index += 1
+                val id = parsingDiaryContent[index]
+                val imageEntity = dreamDiaryDao.getImage(id)
+                if (imageEntity == null) {
+                    diaryContents.add(
+                        NotDownloadedContent.Image(id, synchronizingDreamDiaryEntity.id)
+                    )
+                }
+            } else {
+                index += 1
+            }
+        }
+        return diaryContents
     }
 
     companion object {

--- a/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
+++ b/core/synchronization/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/synchronization/SynchronizationWorker.kt
@@ -185,7 +185,7 @@ class SynchronizationWorker @AssistedInject constructor(
                             imageEntity = ImageEntity(
                                 id = content.id,
                                 path = image.path,
-                            )
+                            ),
                         )
                         dreamDiaryDao.moveToDreamDiaryIfSynced(content.diaryId)
                     }
@@ -196,8 +196,8 @@ class SynchronizationWorker @AssistedInject constructor(
                         dreamDiaryDao.insertText(
                             textEntity = TextEntity(
                                 id = content.id,
-                                text = text.text
-                            )
+                                text = text.text,
+                            ),
                         )
                         dreamDiaryDao.moveToDreamDiaryIfSynced(content.diaryId)
                     }
@@ -220,7 +220,7 @@ class SynchronizationWorker @AssistedInject constructor(
                 val textEntity = dreamDiaryDao.getText(id)
                 if (textEntity == null) {
                     diaryContents.add(
-                        NotDownloadedContent.Text(id, synchronizingDreamDiaryEntity.id)
+                        NotDownloadedContent.Text(id, synchronizingDreamDiaryEntity.id),
                     )
                 }
             } else if (parsingDiaryContent[index] == "image") {
@@ -229,7 +229,7 @@ class SynchronizationWorker @AssistedInject constructor(
                 val imageEntity = dreamDiaryDao.getImage(id)
                 if (imageEntity == null) {
                     diaryContents.add(
-                        NotDownloadedContent.Image(id, synchronizingDreamDiaryEntity.id)
+                        NotDownloadedContent.Image(id, synchronizingDreamDiaryEntity.id),
                     )
                 }
             } else {


### PR DESCRIPTION
## :man_shrugging: Description
서버에만 있는 컨텐트(텍스트, 이미지)를 받아오는 함수입니다. downloadImage는 이미지의 아이디와 path만 가지고 있으며, storage에서 해당 path로 재차 이미지를 받아옵니다.

로그아웃 및 다른 아이디로 로그인을 했을 때 동기화 관련 테이블을 비웁니다.
