### PR TITLE
[fix] `ForegroundServiceStartNotAllowedException`이 발생하는 문제 해결

### DIFF
--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/DreamDiaryApplication.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/DreamDiaryApplication.kt
@@ -1,27 +1,16 @@
 package com.boostcamp.dreamteam.dreamdiary
 
 import android.app.Application
-import android.content.SharedPreferences
 import com.boostcamp.dreamteam.dreamdiary.core.synchronization.SynchronizationWorker
-import com.boostcamp.dreamteam.dreamdiary.notification.createNotificationChannel
-import com.boostcamp.dreamteam.dreamdiary.notification.startTrackingService
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
-import javax.inject.Inject
 
 @HiltAndroidApp
 class DreamDiaryApplication : Application() {
-    @Inject
-    lateinit var sharedPreferences: SharedPreferences
-
     override fun onCreate() {
         super.onCreate()
 
         initTimber()
-        createNotificationChannel(this)
-        if (sharedPreferences.getBoolean("onTracking", false)) {
-            startTrackingService(this)
-        }
         SynchronizationWorker.initWorker(this)
     }
 

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainActivity.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainActivity.kt
@@ -1,17 +1,30 @@
 package com.boostcamp.dreamteam.dreamdiary
 
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import com.boostcamp.dreamteam.dreamdiary.notification.createNotificationChannel
+import com.boostcamp.dreamteam.dreamdiary.notification.startTrackingService
 import com.boostcamp.dreamteam.dreamdiary.ui.DreamDiaryApp
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject
+    lateinit var sharedPreferences: SharedPreferences
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        createNotificationChannel(this)
+        if (sharedPreferences.getBoolean("onTracking", false)) {
+            startTrackingService(this)
+        }
+
         setContent {
             DreamDiaryApp()
         }


### PR DESCRIPTION

<details>
<summary>에러 전문</summary>

```text
java.lang.RuntimeException: Unable to create application com.boostcamp.dreamteam.dreamdiary.DreamDiaryApplication: android.app.ForegroundServiceStartNotAllowedException: startForegroundService() not allowed due to mAllowStartForeground false: service com.boostcamp.dreamteam.dreamdiary/.notification.ScreenTrackingService
                                                                                                                              	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7510)
                                                                                                                              	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
                                                                                                                              	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2416)
                                                                                                                              	at android.os.Handler.dispatchMessage(Handler.java:107)
                                                                                                                              	at android.os.Looper.loopOnce(Looper.java:232)
                                                                                                                              	at android.os.Looper.loop(Looper.java:317)
                                                                                                                              	at android.app.ActivityThread.main(ActivityThread.java:8705)
                                                                                                                              	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                                              	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
                                                                                                                              	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
                                                                                                                              Caused by: android.app.ForegroundServiceStartNotAllowedException: startForegroundService() not allowed due to mAllowStartForeground false: service com.boostcamp.dreamteam.dreamdiary/.notification.ScreenTrackingService
                                                                                                                              	at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:54)
                                                                                                                              	at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel(ForegroundServiceStartNotAllowedException.java:50)
                                                                                                                              	at android.os.Parcel.readParcelableInternal(Parcel.java:5075)
                                                                                                                              	at android.os.Parcel.readParcelable(Parcel.java:5057)
                                                                                                                              	at android.os.Parcel.createExceptionOrNull(Parcel.java:3237)
                                                                                                                              	at android.os.Parcel.createException(Parcel.java:3226)
                                                                                                                              	at android.os.Parcel.readException(Parcel.java:3209)
                                                                                                                              	at android.os.Parcel.readException(Parcel.java:3151)
                                                                                                                              	at android.app.IActivityManager$Stub$Proxy.startService(IActivityManager.java:6393)
                                                                                                                              	at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1960)
                                                                                                                              	at android.app.ContextImpl.startForegroundService(ContextImpl.java:1935)
                                                                                                                              	at android.content.ContextWrapper.startForegroundService(ContextWrapper.java:832)
                                                                                                                              	at androidx.core.content.ContextCompat$Api26Impl.startForegroundService(ContextCompat.java:1130)
                                                                                                                              	at androidx.core.content.ContextCompat.startForegroundService(ContextCompat.java:711)
                                                                                                                              	at com.boostcamp.dreamteam.dreamdiary.notification.NotificationKt.startTrackingService(Notification.kt:67)
                                                                                                                              	at com.boostcamp.dreamteam.dreamdiary.DreamDiaryApplication.onCreate(DreamDiaryApplication.kt:23)
                                                                                                                              	at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1386)
                                                                                                                              	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7504)
                                                                                                                              	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0) 
                                                                                                                              	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2416) 
                                                                                                                              	at android.os.Handler.dispatchMessage(Handler.java:107) 
                                                                                                                              	at android.os.Looper.loopOnce(Looper.java:232) 
                                                                                                                              	at android.os.Looper.loop(Looper.java:317) 
                                                                                                                              	at android.app.ActivityThread.main(ActivityThread.java:8705) 
                                                                                                                              	at java.lang.reflect.Method.invoke(Native Method) 
                                                                                                                              	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580) 
                                                                                                                              	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886) 
```

</details>

## :man_shrugging: Description

앱이 종료되었을 때 widget으로 앱을 실행하게 되면 `ForegroundServiceStartNotAllowedException`이 발생합니다.  

### 원인

앱이 foreground가 아닌 상태에서 foreground service를 실행하려 하기 때문

### 해결

notification 등록을 application이 아닌 activity에서 하도록 변경
