### PR TITLE
[feat] 신규 댓글 입력창 크기 줄이기

### DIFF
--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/detail/CommunityDetailScreen.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/detail/CommunityDetailScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
@@ -220,11 +221,15 @@ private fun NewCommentBottomBar(
                 value = state.inputComment,
                 onValueChange = {
                     state.onInputCommentChange(it)
-                    shouldShowSendButton = it.isNotBlank()
                 },
                 modifier = Modifier
                     .weight(1f)
                     .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
+                            shouldShowSendButton = true
+                        }
+                    }
                     .padding(8.dp),
                 textStyle = MaterialTheme.typography.bodyMedium.copy(
                     color = MaterialTheme.colorScheme.onSurface,
@@ -244,6 +249,7 @@ private fun NewCommentBottomBar(
             )
             if (shouldShowSendButton) {
                 IconButton(
+                    enabled = state.inputComment.isNotBlank(),
                     onClick = state.onSubmitComment,
                     modifier = Modifier.size(36.dp),
                 ) {


### PR DESCRIPTION
<!-- ex) close #10, resolves #123 -->

## :man_shrugging: Description

이전의 입력창이 너무 큰 것 같아 줄였습니다. 디자인은 유튜브의 댓글 입력창을 참고했습니다.

## :camera: Screenshots

![image](https://github.com/user-attachments/assets/be81c90f-870f-408f-8a16-e83e93d5c3b4)

