### PR TITLE
[fix] server timestamp를 map으로 추가하지 않게 변경

### DIFF
--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/firestore/model/FirestoreAddCommunityPostRequest.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/firebase/firestore/model/FirestoreAddCommunityPostRequest.kt
@@ -1,6 +1,8 @@
 package com.boostcamp.dreamteam.dreamdiary.core.data.firebase.firestore.model
 
+import com.google.firebase.firestore.FieldValue
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 data class FirestoreAddCommunityPostRequest(
@@ -12,4 +14,6 @@ data class FirestoreAddCommunityPostRequest(
     val content: String,
     val likeCount: Int,
     val commentCount: Long,
+    @Transient
+    val createdAt: FieldValue = FieldValue.serverTimestamp(),
 )

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/CommunityRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/CommunityRepository.kt
@@ -5,7 +5,6 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
-import com.boostcamp.dreamteam.dreamdiary.core.data.convertToFirebaseData
 import com.boostcamp.dreamteam.dreamdiary.core.data.dto.CommunityPostResponse
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.FirebaseCommunityPostPagingSource
 import com.boostcamp.dreamteam.dreamdiary.core.data.firebase.firestore.model.FirestoreAddCommunityPostRequest
@@ -13,15 +12,11 @@ import com.boostcamp.dreamteam.dreamdiary.core.model.CommunityPostDetail
 import com.boostcamp.dreamteam.dreamdiary.core.model.DiaryContent
 import com.boostcamp.dreamteam.dreamdiary.core.model.community.CommunityPostList
 import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
 import timber.log.Timber
 import java.io.File
 import java.time.Instant
@@ -102,11 +97,8 @@ class CommunityRepository @Inject constructor(
             commentCount = 0,
         )
 
-        val requestMap = (Json.encodeToJsonElement(request).jsonObject.convertToFirebaseData() as Map<String, Any>).toMutableMap()
-        requestMap["createdAt"] = FieldValue.serverTimestamp()
-
         firebaseFirestore.runBatch { batch ->
-            batch.set(postReference, requestMap)
+            batch.set(postReference, request)
             for ((reference, data) in referenceToData) {
                 batch.set(reference, data)
             }


### PR DESCRIPTION
## :man_shrugging: Description

```
@Serializable
data class FirestoreAddCommunityPostRequest(
    val id: String,
    val uid: String,
    val author: String,
    val profileImageUrl: String,
    val title: String,
    val content: String,
    val likeCount: Int,
    val commentCount: Long,
    @Transient
    val createdAt: FieldValue = FieldValue.serverTimestamp(),
)

```

이렇게 해보는 것은 어떨까요?
수정을 제안해봅니다.