### PR TITLE
[feat] 테마 색상 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,8 @@ android {
 }
 
 dependencies {
+    implementation(projects.core.data)
+    implementation(projects.core.model)
     implementation(projects.core.designsystem)
     implementation(projects.core.notification)
     implementation(projects.feature.auth)
@@ -55,6 +57,7 @@ dependencies {
     implementation(projects.core.synchronization)
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.hilt.navigation.compose)

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainActivity.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainActivity.kt
@@ -62,6 +62,7 @@ class MainActivity : ComponentActivity() {
                 SettingThemeUiState.System, SettingThemeUiState.Loading -> {
                     isSystemInDarkTheme()
                 }
+
                 else -> {
                     settingTheme == SettingThemeUiState.Dark
                 }

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainActivity.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainActivity.kt
@@ -3,12 +3,22 @@ package com.boostcamp.dreamteam.dreamdiary
 import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.boostcamp.dreamteam.dreamdiary.notification.createNotificationChannel
 import com.boostcamp.dreamteam.dreamdiary.notification.startTrackingService
 import com.boostcamp.dreamteam.dreamdiary.ui.DreamDiaryApp
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -16,8 +26,29 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var sharedPreferences: SharedPreferences
 
+    private val viewModel: MainViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+
+        val uiState = mutableStateOf(MainUiState())
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect {
+                    uiState.value = it
+                }
+            }
+        }
+
+        splashScreen.setKeepOnScreenCondition {
+            when (uiState.value.settingThemeUiState) {
+                SettingThemeUiState.Loading -> true
+                else -> false
+            }
+        }
+
         enableEdgeToEdge()
 
         createNotificationChannel(this)
@@ -26,7 +57,35 @@ class MainActivity : ComponentActivity() {
         }
 
         setContent {
-            DreamDiaryApp()
+            val settingTheme = uiState.value.settingThemeUiState
+            val darkTheme = when (settingTheme) {
+                SettingThemeUiState.System, SettingThemeUiState.Loading -> {
+                    isSystemInDarkTheme()
+                }
+                else -> {
+                    settingTheme == SettingThemeUiState.Dark
+                }
+            }
+
+            DisposableEffect(darkTheme) {
+                enableEdgeToEdge(
+                    statusBarStyle = SystemBarStyle.auto(
+                        android.graphics.Color.TRANSPARENT,
+                        android.graphics.Color.TRANSPARENT,
+                    ) { darkTheme },
+                    navigationBarStyle = SystemBarStyle.auto(
+                        lightScrim,
+                        darkScrim,
+                    ) { darkTheme },
+                )
+                onDispose {}
+            }
+
+            DreamDiaryApp(darkTheme)
         }
     }
 }
+
+// NIA 발췌
+private val lightScrim = android.graphics.Color.argb(0xe6, 0xFF, 0xFF, 0xFF)
+private val darkScrim = android.graphics.Color.argb(0x80, 0x1b, 0x1b, 0x1b)

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainUiState.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainUiState.kt
@@ -1,0 +1,12 @@
+package com.boostcamp.dreamteam.dreamdiary
+
+data class MainUiState(
+    val settingThemeUiState: SettingThemeUiState = SettingThemeUiState.Loading,
+)
+
+sealed class SettingThemeUiState {
+    data object Loading : SettingThemeUiState()
+    data object System : SettingThemeUiState()
+    data object Light: SettingThemeUiState()
+    data object Dark: SettingThemeUiState()
+}

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainUiState.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainUiState.kt
@@ -6,7 +6,10 @@ data class MainUiState(
 
 sealed class SettingThemeUiState {
     data object Loading : SettingThemeUiState()
+
     data object System : SettingThemeUiState()
-    data object Light: SettingThemeUiState()
-    data object Dark: SettingThemeUiState()
+
+    data object Light : SettingThemeUiState()
+
+    data object Dark : SettingThemeUiState()
 }

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainViewModel.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainViewModel.kt
@@ -1,0 +1,27 @@
+package com.boostcamp.dreamteam.dreamdiary
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.dreamteam.dreamdiary.core.data.repository.SettingThemeRepository
+import com.boostcamp.dreamteam.dreamdiary.core.model.setting.SettingTheme
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val settingThemeRepository: SettingThemeRepository,
+) : ViewModel() {
+
+    // TODO flowWithStarted로 변경
+    val uiState = settingThemeRepository.getTheme()
+        .map {
+            when (it) {
+                SettingTheme.SYSTEM -> MainUiState(SettingThemeUiState.System)
+                SettingTheme.LIGHT -> MainUiState(SettingThemeUiState.Light)
+                SettingTheme.DARK -> MainUiState(SettingThemeUiState.Dark)
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, MainUiState())
+}

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainViewModel.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/MainViewModel.kt
@@ -14,7 +14,6 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     private val settingThemeRepository: SettingThemeRepository,
 ) : ViewModel() {
-
     // TODO flowWithStarted로 변경
     val uiState = settingThemeRepository.getTheme()
         .map {

--- a/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/ui/DreamDiaryApp.kt
+++ b/app/src/main/java/com/boostcamp/dreamteam/dreamdiary/ui/DreamDiaryApp.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.dreamteam.dreamdiary.ui
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
@@ -7,10 +8,13 @@ import com.boostcamp.dreamteam.dreamdiary.navigation.DreamDiaryNavHost
 
 @Composable
 internal fun DreamDiaryApp(
+    darkTheme: Boolean = isSystemInDarkTheme(),
     appState: DreamDiaryAppState = rememberAppState(),
     modifier: Modifier = Modifier,
 ) {
-    DreamdiaryTheme {
+    DreamdiaryTheme(
+        darkTheme = darkTheme,
+    ) {
         DreamDiaryNavHost(appState = appState)
     }
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -53,4 +53,6 @@ dependencies {
     implementation(libs.androidx.credentials.play.services.auth)
 
     implementation(libs.kotlinx.serialization.json.jvm)
+
+    implementation(libs.androidx.datastore.preferences)
 }

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/CommunityRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/CommunityRepository.kt
@@ -12,6 +12,7 @@ import com.boostcamp.dreamteam.dreamdiary.core.model.CommunityPostDetail
 import com.boostcamp.dreamteam.dreamdiary.core.model.DiaryContent
 import com.boostcamp.dreamteam.dreamdiary.core.model.community.CommunityPostList
 import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.flow.Flow

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/SettingThemeRepository.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/SettingThemeRepository.kt
@@ -1,0 +1,33 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.boostcamp.dreamteam.dreamdiary.core.data.repository.di.SettingThemeDataStore
+import com.boostcamp.dreamteam.dreamdiary.core.model.setting.SettingTheme
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SettingThemeRepository @Inject constructor(
+    @SettingThemeDataStore private val dataStore: DataStore<Preferences>,
+) {
+    private val key = stringPreferencesKey("selected_setting_theme")
+
+    fun getTheme(): Flow<SettingTheme> {
+        return dataStore.data.map {
+            val theme = it[key] ?: SettingTheme.SYSTEM.name
+            SettingTheme.valueOf(theme)
+        }
+    }
+
+    suspend fun setTheme(theme: SettingTheme) {
+        dataStore.updateData {
+            it.toMutablePreferences().apply {
+                this[key] = theme.name
+            }
+        }
+    }
+}

--- a/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/di/SettingThemeModule.kt
+++ b/core/data/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/data/repository/di/SettingThemeModule.kt
@@ -1,0 +1,34 @@
+package com.boostcamp.dreamteam.dreamdiary.core.data.repository.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SettingThemeModule {
+    @Provides
+    @Singleton
+    @SettingThemeDataStore
+    fun providePreferenceStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            produceFile = {
+                context.preferencesDataStoreFile("setting_theme")
+            },
+        )
+    }
+}
+
+@Qualifier
+annotation class SettingThemeDataStore

--- a/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/setting/SettingTheme.kt
+++ b/core/model/src/main/java/com/boostcamp/dreamteam/dreamdiary/core/model/setting/SettingTheme.kt
@@ -1,0 +1,7 @@
+package com.boostcamp.dreamteam.dreamdiary.core.model.setting
+
+enum class SettingTheme {
+    SYSTEM,
+    LIGHT,
+    DARK,
+}

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
@@ -258,6 +259,9 @@ private fun DiaryHomeScreenTopAppBar(
 
     Column(modifier = modifier) {
         CenterAlignedTopAppBar(
+            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = Color.Transparent
+            ),
             title = { Text(stringResource(R.string.home_my_dream)) },
             actions = {
                 DiarySyncIconButton(

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/DiaryHomeScreen.kt
@@ -260,7 +260,7 @@ private fun DiaryHomeScreenTopAppBar(
     Column(modifier = modifier) {
         CenterAlignedTopAppBar(
             colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                containerColor = Color.Transparent
+                containerColor = Color.Transparent,
             ),
             title = { Text(stringResource(R.string.home_my_dream)) },
             actions = {

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingNavigation.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navOptions
 import androidx.navigation.navigation
+import com.boostcamp.dreamteam.dreamdiary.setting.theme.SettingThemeScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -20,6 +21,9 @@ data object SettingGraph {
 
     @Serializable
     data class SettingDetailRoute(val id: Long)
+
+    @Serializable
+    data object SettingThemeRoute
 }
 
 fun NavGraphBuilder.settingGraph(
@@ -51,6 +55,14 @@ fun NavGraphBuilder.settingGraph(
                         },
                     )
                 },
+                onNavigateToSettingTheme = {
+                    navController.navigate(
+                        SettingGraph.SettingThemeRoute,
+                        navOptions = navOptions {
+                            launchSingleTop = true
+                        },
+                    )
+                },
                 onGoToSignInClick = onGoToSignInClick,
             )
         }
@@ -61,6 +73,11 @@ fun NavGraphBuilder.settingGraph(
         }
         composable<SettingGraph.SettingBackupRoute> {
             SettingBackupScreen(
+                onBackClick = navController::navigateUp,
+            )
+        }
+        composable<SettingGraph.SettingThemeRoute> {
+            SettingThemeScreen(
                 onBackClick = navController::navigateUp,
             )
         }

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/SettingScreen.kt
@@ -49,6 +49,7 @@ internal fun SettingScreen(
     onNavigateToCommunity: () -> Unit,
     onNavigateToSettingNotification: () -> Unit,
     onNavigateToSettingBackup: () -> Unit,
+    onNavigateToSettingTheme: () -> Unit,
     onGoToSignInClick: () -> Unit,
     modifier: Modifier = Modifier,
     settingViewModel: SettingViewModel = hiltViewModel(),
@@ -72,6 +73,7 @@ internal fun SettingScreen(
         onGoToSignInClick = onGoToSignInClick,
         onNavigateToSettingNotification = onNavigateToSettingNotification,
         onNavigateToSettingBackup = onNavigateToSettingBackup,
+        onNavigateToSettingTheme = onNavigateToSettingTheme,
         modifier = modifier,
         signInProvider = settingViewModel.getSignInProvider(),
         userEmail = email,
@@ -86,6 +88,7 @@ private fun SettingScreenContent(
     onGoToSignInClick: () -> Unit,
     onNavigateToSettingNotification: () -> Unit,
     onNavigateToSettingBackup: () -> Unit,
+    onNavigateToSettingTheme: () -> Unit,
     signInProvider: String?,
     onSignOut: () -> Unit,
     userEmail: String?,
@@ -110,6 +113,7 @@ private fun SettingScreenContent(
             onGoToSignInClick = onGoToSignInClick,
             onNavigateToSettingNotification = onNavigateToSettingNotification,
             onNavigateToSettingBackup = onNavigateToSettingBackup,
+            onNavigateToSettingTheme = onNavigateToSettingTheme,
             onSignOut = onSignOut,
             modifier = Modifier.padding(innerPadding),
         )
@@ -123,6 +127,7 @@ private fun SettingScreenBody(
     onGoToSignInClick: () -> Unit,
     onNavigateToSettingNotification: () -> Unit,
     onNavigateToSettingBackup: () -> Unit,
+    onNavigateToSettingTheme: () -> Unit,
     onSignOut: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -180,6 +185,9 @@ private fun SettingScreenBody(
         SettingOption(
             icon = Icons.Outlined.DarkMode,
             text = stringResource(R.string.setting_darkmode),
+            onClick = {
+                onNavigateToSettingTheme()
+            },
         )
         SettingOption(
             icon = Icons.Outlined.Lock,
@@ -237,6 +245,7 @@ private fun SettingScreenPreview() {
             onGoToSignInClick = {},
             onNavigateToSettingNotification = {},
             onNavigateToSettingBackup = {},
+            onNavigateToSettingTheme = {},
             signInProvider = "Google",
             onSignOut = {},
             userEmail = "someone@example.com",

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeScreen.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeScreen.kt
@@ -36,14 +36,16 @@ import com.boostcamp.dreamteam.dreamdiary.setting.R
 
 @Composable
 fun SettingThemeScreen(
-    settingThemeViewModel: SettingThemeViewModel = hiltViewModel(),
     onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    settingThemeViewModel: SettingThemeViewModel = hiltViewModel(),
 ) {
     val settingTheme by settingThemeViewModel.settingTheme.collectAsStateWithLifecycle()
     SettingThemeScreenContent(
         onBackClick = onBackClick,
         settingTheme = settingTheme,
         onSettingThemeChange = settingThemeViewModel::setSettingTheme,
+        modifier = modifier,
     )
 }
 
@@ -53,10 +55,10 @@ fun SettingThemeScreenContent(
     onBackClick: () -> Unit,
     settingTheme: SettingTheme,
     onSettingThemeChange: (SettingTheme) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Scaffold(
-        modifier = Modifier
-            .fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         topBar = {
             CenterAlignedTopAppBar(
                 colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
@@ -105,9 +107,10 @@ fun SettingThemeRadio(
     text: String,
     selected: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        Modifier
+        modifier = modifier
             .fillMaxWidth()
             .selectable(
                 selected = selected,

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeScreen.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeScreen.kt
@@ -18,10 +18,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,6 +59,9 @@ fun SettingThemeScreenContent(
             .fillMaxSize(),
         topBar = {
             CenterAlignedTopAppBar(
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = Color.Transparent
+                ),
                 title = {
                     Text(text = stringResource(R.string.setting_theme_title))
                 },

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeScreen.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeScreen.kt
@@ -1,0 +1,134 @@
+package com.boostcamp.dreamteam.dreamdiary.setting.theme
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.boostcamp.dreamteam.dreamdiary.core.model.setting.SettingTheme
+import com.boostcamp.dreamteam.dreamdiary.designsystem.theme.DreamdiaryTheme
+import com.boostcamp.dreamteam.dreamdiary.setting.R
+
+@Composable
+fun SettingThemeScreen(
+    settingThemeViewModel: SettingThemeViewModel = hiltViewModel(),
+    onBackClick: () -> Unit,
+) {
+    val settingTheme by settingThemeViewModel.settingTheme.collectAsStateWithLifecycle()
+    SettingThemeScreenContent(
+        onBackClick = onBackClick,
+        settingTheme = settingTheme,
+        onSettingThemeChange = settingThemeViewModel::setSettingTheme,
+    )
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun SettingThemeScreenContent(
+    onBackClick: () -> Unit,
+    settingTheme: SettingTheme,
+    onSettingThemeChange: (SettingTheme) -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize(),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(text = stringResource(R.string.setting_theme_title))
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.setting_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) {
+        Column(
+            Modifier
+                .padding(it)
+                .selectableGroup(),
+        ) {
+            SettingThemeRadio(
+                text = stringResource(R.string.setting_theme_system),
+                selected = settingTheme == SettingTheme.SYSTEM,
+                onClick = { onSettingThemeChange(SettingTheme.SYSTEM) },
+            )
+            SettingThemeRadio(
+                text = stringResource(R.string.setting_theme_light),
+                selected = settingTheme == SettingTheme.LIGHT,
+                onClick = { onSettingThemeChange(SettingTheme.LIGHT) },
+            )
+            SettingThemeRadio(
+                text = stringResource(R.string.setting_theme_dark),
+                selected = settingTheme == SettingTheme.DARK,
+                onClick = { onSettingThemeChange(SettingTheme.DARK) },
+            )
+        }
+    }
+}
+
+@Composable
+fun SettingThemeRadio(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                role = Role.RadioButton,
+                onClick = onClick,
+            )
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = null,
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(text)
+    }
+}
+
+@Preview
+@Composable
+private fun SettingThemeScreenContentPreview() {
+    DreamdiaryTheme {
+        SettingThemeScreenContent(
+            onBackClick = {},
+            settingTheme = SettingTheme.SYSTEM,
+            onSettingThemeChange = {},
+        )
+    }
+}

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeScreen.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeScreen.kt
@@ -60,7 +60,7 @@ fun SettingThemeScreenContent(
         topBar = {
             CenterAlignedTopAppBar(
                 colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = Color.Transparent
+                    containerColor = Color.Transparent,
                 ),
                 title = {
                     Text(text = stringResource(R.string.setting_theme_title))

--- a/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeViewModel.kt
+++ b/feature/setting/src/main/java/com/boostcamp/dreamteam/dreamdiary/setting/theme/SettingThemeViewModel.kt
@@ -1,0 +1,26 @@
+package com.boostcamp.dreamteam.dreamdiary.setting.theme
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boostcamp.dreamteam.dreamdiary.core.data.repository.SettingThemeRepository
+import com.boostcamp.dreamteam.dreamdiary.core.model.setting.SettingTheme
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingThemeViewModel @Inject constructor(
+    private val settingThemeRepository: SettingThemeRepository,
+) : ViewModel() {
+    val settingTheme = settingThemeRepository
+        .getTheme()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SettingTheme.SYSTEM)
+
+    fun setSettingTheme(newSettingTheme: SettingTheme) {
+        viewModelScope.launch {
+            settingThemeRepository.setTheme(newSettingTheme)
+        }
+    }
+}

--- a/feature/setting/src/main/res/values/strings.xml
+++ b/feature/setting/src/main/res/values/strings.xml
@@ -33,4 +33,8 @@
     <string name="setting_confirm">확인</string>
     <string name="setting_notification_authority">알림 권한</string>
     <string name="setting_notification_wakeup">기상 알림</string>
+    <string name="setting_theme_system">시스템</string>
+    <string name="setting_theme_light">라이트</string>
+    <string name="setting_theme_dark">다크</string>
+    <string name="setting_theme_title">테마 설정</string>
 </resources>

--- a/feature/setting/src/main/res/values/strings.xml
+++ b/feature/setting/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="setting_subscribe">구독중</string>
     <string name="setting_communication">커뮤니케이션</string>
     <string name="setting_picture">꿈 사진으로 보기</string>
-    <string name="setting_darkmode">다크모드 설정</string>
+    <string name="setting_darkmode">테마 설정</string>
     <string name="setting_information">정보</string>
     <string name="setting_lock_setting">잠금설정</string>
     <string name="setting_check_account">로그인된 SNS 계정 확인</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.7.1"
 credentials = "1.5.0-beta01"
+datastorePreferences = "1.1.1"
 desugar_jdk_libs = "2.0.3"
 androidxHilt = "1.2.0"
 kotlin = "2.0.21"
@@ -36,6 +37,7 @@ workRuntimeKtx = "2.10.0"
 [libraries]
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidxHilt" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidxHilt" }
 androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidxHilt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,10 +33,12 @@ firebaseCrashlytics = "3.0.2"
 browser = "1.8.0"
 glance = "1.1.1"
 workRuntimeKtx = "2.10.0"
+androidxCoreSplashscreen = "1.0.1"
 
 [libraries]
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidxCoreSplashscreen" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidxHilt" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidxHilt" }


### PR DESCRIPTION
## :man_shrugging: Description
설정에 "다크모드 설정"을 "테마 설정"으로 변경하고, 누르면 테마 설정 화면으로 넘어가 시스템, 라이트, 다크 중 하나를 선택할 수 있습니다.

nia를 참고하여 `setKeepOnScreenCondition` 호출이나 `enableEdgeToEdge`를 재차 호출하는 코드를 작성했습니다.

`setKeepOnScreenCondition`는 테마 설정을 읽어 들일 때까지 스플래시 화면을 계속 띄워주는데 사용합니다. 이걸 안하면 설정을 읽기 전 시스템 테마를 따라갔다가 설정을 다 읽은 후 해당 설정으로 바뀌어, 시스템 테마가 라이트이고 앱 테마를 다크로 해두었을 경우 라이트 -> 다크로 넘어가는 깜빡임이 보입니다.

`enableEdgeToEdge`를 재차 호출하는 부분은, 상태 바나 네비게이션 바가 시스템의 테마를 따라가는 걸 방지하는 용도로 보입니다. 이걸 안하면 시스템 테마가 라이트인데 앱 테마를 다크로 해두었을 때, 앱 화면은 다크인데 네비게이션은 하얗습니다.
