### PR TITLE
[fix] takePersistableUriPermission의 익셉션 처리

### DIFF
--- a/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/write/CommunityWriteScreen.kt
+++ b/feature/community/src/main/java/com/boostcamp/dreamteam/dreamdiary/community/write/CommunityWriteScreen.kt
@@ -105,10 +105,13 @@ private fun CommunityWriteScreenContent(
         contract = ActivityResultContracts.PickVisualMedia(),
         onResult = { uri ->
             uri?.let {
-                context.contentResolver.takePersistableUriPermission(
-                    uri,
-                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
-                )
+                try {
+                    context.contentResolver.takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                    )
+                } catch (ignored: SecurityException) {
+                }
                 onContentImageAdd(
                     currentFocusContent,
                     currentTextCursorPosition,

--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/write/DiaryWriteScreen.kt
@@ -181,7 +181,13 @@ private fun DiaryWriteScreenContent(
         contract = ActivityResultContracts.PickVisualMedia(),
         onResult = { uri ->
             uri?.let {
-                context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                try {
+                    context.contentResolver.takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                    )
+                } catch (ignored: SecurityException) {
+                }
                 coroutineScope.launch(Dispatchers.IO) {
                     val fileName = UUID.randomUUID().toString()
                     val inputStream = context.contentResolver.openInputStream(uri)


### PR DESCRIPTION
#258 

## :man_shrugging: Description
`takePersistableUriPermission`를 실패하는 기종이 있는 것 같습니다. `SecurityException`를 내뿜는데, 이를 무시하도록 했습니다.
해당 함수는 이 uri를, 앱을 껐다 켰을 때에도 접근 권한을 가지게 하는 함수로 알고 있습니다. 반대로 이 함수를 호출하지 않으면 임시적인 권한이므로 항상 호출하게 해 두었는데, 사실 우리 앱에서는 화면이 있을 때 이미지를 업로드하므로 임시적인 권한으로도 모두 처리가 가능할 것으로 생각됩니다.

실제로 이 함수 호출이 실패했을 때에는, cache 폴더 등에 복사해서 그 파일을 이용하는게 가장 완벽한 해결법인 것 같습니다.
