### PR TITLE
[fix] 달력 bottomSheet listItem 가로 크기 늘리기

### DIFF
--- a/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
+++ b/feature/diary/src/main/java/com/boostcamp/dreamteam/dreamdiary/feature/diary/home/component/DiaryCalendarBottomSheet.kt
@@ -193,7 +193,9 @@ private fun ListBottomSheet(
                 headlineContent = {
                     Text(text = diary.title)
                 },
-                modifier = Modifier.clickable { onDiaryClick(diary) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onDiaryClick(diary) },
                 overlineContent = {
                     Text(text = diary.sortKey.value.format(dateTimeFormatter))
                 },


### PR DESCRIPTION
closes #263 

## :man_shrugging: Description

가로 길이가 짧아서 보이는 영역이 짧았던 것 같습니다.
